### PR TITLE
Few balance tweaks and changes to some mobs

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityAlligatorSnappingTurtle.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityAlligatorSnappingTurtle.java
@@ -91,7 +91,7 @@ public class EntityAlligatorSnappingTurtle extends AnimalEntity implements ISemi
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.7D).createMutableAttribute(Attributes.ARMOR, 8D).createMutableAttribute(Attributes.FOLLOW_RANGE, 16.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.2F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 18.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.7D).createMutableAttribute(Attributes.ARMOR, 8D).createMutableAttribute(Attributes.FOLLOW_RANGE, 16.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.2F);
     }
 
     public float getRenderScale() {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityBoneSerpent.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityBoneSerpent.java
@@ -83,7 +83,7 @@ public class EntityBoneSerpent extends MonsterEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 25.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 5.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 1.0F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 25.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 5.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 1.45F);
     }
 
     public int getMaxFallHeight() {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityBoneSerpent.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityBoneSerpent.java
@@ -83,7 +83,7 @@ public class EntityBoneSerpent extends MonsterEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 64.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 1.45F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 25.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 5.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 1.0F);
     }
 
     public int getMaxFallHeight() {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCapuchinMonkey.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCapuchinMonkey.java
@@ -156,7 +156,7 @@ public class EntityCapuchinMonkey extends TameableEntity implements IAnimatedEnt
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 18D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.4F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 8.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.4F);
     }
 
     public void writeAdditional(CompoundNBT compound) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCapuchinMonkey.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCapuchinMonkey.java
@@ -156,7 +156,7 @@ public class EntityCapuchinMonkey extends TameableEntity implements IAnimatedEnt
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 8.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.4F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 10.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.4F);
     }
 
     public void writeAdditional(CompoundNBT compound) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCentipedeBody.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCentipedeBody.java
@@ -230,7 +230,7 @@ public class EntityCentipedeBody extends MobEntity implements IHurtableMultipart
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 10.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 12.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 8.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 10.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 6.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 8.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCentipedeHead.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCentipedeHead.java
@@ -72,7 +72,7 @@ public class EntityCentipedeHead extends MonsterEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 6.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 7.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.22F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 35.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 6.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 8.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.22F);
     }
 
     protected void playStepSound(BlockPos pos, BlockState blockIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCentipedeHead.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCentipedeHead.java
@@ -72,7 +72,7 @@ public class EntityCentipedeHead extends MonsterEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 60.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 12.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 8.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.2F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 6.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 7.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.22F);
     }
 
     protected void playStepSound(BlockPos pos, BlockState blockIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCrimsonMosquito.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCrimsonMosquito.java
@@ -109,7 +109,7 @@ public class EntityCrimsonMosquito extends MonsterEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 2.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 5.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 10.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 5.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     @Nullable

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCrocodile.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCrocodile.java
@@ -100,7 +100,7 @@ public class EntityCrocodile extends TameableEntity implements IAnimatedEntity, 
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20.0D).createMutableAttribute(Attributes.ARMOR, 10.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.4F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.20F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20.0D).createMutableAttribute(Attributes.ARMOR, 10.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.4F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     public boolean canSpawn(IWorld worldIn, SpawnReason spawnReasonIn) {
@@ -248,7 +248,7 @@ public class EntityCrocodile extends TameableEntity implements IAnimatedEntity, 
         }
         if (this.getAttackTarget() != null && !hasSpedUp) {
             hasSpedUp = true;
-            this.getAttribute(Attributes.MOVEMENT_SPEED).setBaseValue(0.35F);
+            this.getAttribute(Attributes.MOVEMENT_SPEED).setBaseValue(0.28F);
         }
         if (this.getAttackTarget() == null && hasSpedUp) {
             hasSpedUp = false;

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCrocodile.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCrocodile.java
@@ -100,7 +100,7 @@ public class EntityCrocodile extends TameableEntity implements IAnimatedEntity, 
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30.0D).createMutableAttribute(Attributes.ARMOR, 10.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.4F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20.0D).createMutableAttribute(Attributes.ARMOR, 10.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.4F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.20F);
     }
 
     public boolean canSpawn(IWorld worldIn, SpawnReason spawnReasonIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCrocodile.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCrocodile.java
@@ -100,7 +100,7 @@ public class EntityCrocodile extends TameableEntity implements IAnimatedEntity, 
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20.0D).createMutableAttribute(Attributes.ARMOR, 10.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.4F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 40.0D).createMutableAttribute(Attributes.ARMOR, 8.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.4F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     public boolean canSpawn(IWorld worldIn, SpawnReason spawnReasonIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityElephant.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityElephant.java
@@ -135,7 +135,7 @@ public class EntityElephant extends TameableEntity implements ITargetsDroppedIte
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 80.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.9F).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.35F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 65.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.9F).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.35F);
     }
 
     @Nullable
@@ -780,11 +780,11 @@ public class EntityElephant extends TameableEntity implements ITargetsDroppedIte
     public void setTusked(boolean tusked) {
         boolean prev = isTusked();
         if (!prev && tusked) {
-            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(150.0D);
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(80.0D);
             this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(15.0D);
             this.setHealth(150.0F);
         } else {
-            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(80.0D);
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(65.0D);
             this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(10.0D);
         }
         this.dataManager.set(TUSKED, tusked);

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityEndergrade.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityEndergrade.java
@@ -60,7 +60,7 @@ public class EntityEndergrade extends AnimalEntity implements IFlyingAnimal {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30D).createMutableAttribute(Attributes.ARMOR, 4.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.15F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.15F);
     }
 
     public void writeAdditional(CompoundNBT compound) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGazelle.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGazelle.java
@@ -184,7 +184,7 @@ public class EntityGazelle extends AnimalEntity implements IAnimatedEntity, IHer
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 16.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 8.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     @Nullable

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGorilla.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGorilla.java
@@ -89,7 +89,7 @@ public class EntityGorilla extends TameableEntity implements IAnimatedEntity, IT
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 40.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 12.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 8.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 7.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     public static boolean isBanana(ItemStack stack) {
@@ -443,16 +443,16 @@ public class EntityGorilla extends TameableEntity implements IAnimatedEntity, IT
         if (isSilverback() && !isChild() && !hasSilverbackAttributes) {
             hasSilverbackAttributes = true;
             recalculateSize();
-            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(100F);
-            this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(20F);
-            this.heal(100F);
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(40F);
+            this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(10F);
+            this.heal(40F);
         }
         if (!isSilverback() && !isChild() && hasSilverbackAttributes) {
             hasSilverbackAttributes = false;
             recalculateSize();
-            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(40F);
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(20F);
             this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(8F);
-            this.heal(40F);
+            this.heal(20F);
         }
         AnimationHandler.INSTANCE.updateAnimations(this);
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGorilla.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGorilla.java
@@ -89,7 +89,7 @@ public class EntityGorilla extends TameableEntity implements IAnimatedEntity, IT
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 7.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 7.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     public static boolean isBanana(ItemStack stack) {
@@ -443,16 +443,16 @@ public class EntityGorilla extends TameableEntity implements IAnimatedEntity, IT
         if (isSilverback() && !isChild() && !hasSilverbackAttributes) {
             hasSilverbackAttributes = true;
             recalculateSize();
-            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(40F);
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(50F);
             this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(10F);
-            this.heal(40F);
+            this.heal(50F);
         }
         if (!isSilverback() && !isChild() && hasSilverbackAttributes) {
             hasSilverbackAttributes = false;
             recalculateSize();
-            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(20F);
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(30F);
             this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(8F);
-            this.heal(20F);
+            this.heal(30F);
         }
         AnimationHandler.INSTANCE.updateAnimations(this);
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGrizzlyBear.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGrizzlyBear.java
@@ -78,7 +78,7 @@ public class EntityGrizzlyBear extends TameableEntity implements IAngerable, IAn
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 50.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 5.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.6F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.35F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 35.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.6F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     public boolean canSpawn(IWorld worldIn, SpawnReason spawnReasonIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGrizzlyBear.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGrizzlyBear.java
@@ -78,7 +78,7 @@ public class EntityGrizzlyBear extends TameableEntity implements IAngerable, IAn
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 35.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.6F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 40.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.6F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     public boolean canSpawn(IWorld worldIn, SpawnReason spawnReasonIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityHammerheadShark.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityHammerheadShark.java
@@ -100,7 +100,7 @@ public class EntityHammerheadShark extends WaterMobEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 40D).createMutableAttribute(Attributes.ARMOR, 10.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 5.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.5F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 5.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.5F);
     }
 
     public static <T extends MobEntity> boolean canHammerheadSharkSpawn(EntityType<EntityHammerheadShark> p_223364_0_, IWorld p_223364_1_, SpawnReason reason, BlockPos p_223364_3_, Random p_223364_4_) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityHummingbird.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityHummingbird.java
@@ -82,7 +82,7 @@ public class EntityHummingbird extends AnimalEntity {
 
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 8.0D).createMutableAttribute(Attributes.FLYING_SPEED, 7F).createMutableAttribute(Attributes.ATTACK_DAMAGE, 0.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.45F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 4.0D).createMutableAttribute(Attributes.FLYING_SPEED, 7F).createMutableAttribute(Attributes.ATTACK_DAMAGE, 0.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.45F);
     }
 
     public boolean isBreedingItem(ItemStack stack) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityKomodoDragon.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityKomodoDragon.java
@@ -263,7 +263,7 @@ public class EntityKomodoDragon extends TameableEntity implements ITargetsDroppe
         }
     }
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.22F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.23F);
     }
 
     @Nullable

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityKomodoDragon.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityKomodoDragon.java
@@ -263,7 +263,7 @@ public class EntityKomodoDragon extends TameableEntity implements ITargetsDroppe
         }
     }
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.22F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.22F);
     }
 
     @Nullable

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityKomodoDragon.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityKomodoDragon.java
@@ -263,7 +263,7 @@ public class EntityKomodoDragon extends TameableEntity implements ITargetsDroppe
         }
     }
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 40D).createMutableAttribute(Attributes.ARMOR, 6.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.22F);
     }
 
     @Nullable

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityLobster.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityLobster.java
@@ -62,7 +62,7 @@ public class EntityLobster extends WaterMobEntity implements ISemiAquatic {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 10D).createMutableAttribute(Attributes.ARMOR, 6.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.15F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 5D).createMutableAttribute(Attributes.ARMOR, 2.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.15F);
     }
 
     public boolean canSpawn(IWorld worldIn, SpawnReason spawnReasonIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityMoose.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityMoose.java
@@ -76,7 +76,7 @@ public class EntityMoose extends AnimalEntity implements IAnimatedEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 70D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 9.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 55D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 7.5D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.5F);
     }
 
     public boolean canSpawn(IWorld worldIn, SpawnReason spawnReasonIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityMungus.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityMungus.java
@@ -82,7 +82,7 @@ public class EntityMungus extends AnimalEntity implements ITargetsDroppedItems, 
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 15D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     public static boolean canMungusSpawn(EntityType type, IWorld worldIn, SpawnReason reason, BlockPos pos, Random randomIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityOrca.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityOrca.java
@@ -91,7 +91,7 @@ public class EntityOrca extends TameableEntity implements IAnimatedEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 60.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 64.0D).createMutableAttribute(Attributes.ARMOR, 4.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.7F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 1.35F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 60.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 64.0D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.7F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 1.35F);
     }
 
     protected PathNavigator createNavigator(World worldIn) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityRaccoon.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityRaccoon.java
@@ -236,7 +236,7 @@ public class EntityRaccoon extends TameableEntity implements IAnimatedEntity, IF
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 9D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     public boolean attackEntityFrom(DamageSource source, float amount) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityRattlesnake.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityRattlesnake.java
@@ -187,7 +187,7 @@ public class EntityRattlesnake extends AnimalEntity implements IAnimatedEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 16D).createMutableAttribute(Attributes.ARMOR, 4.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 8D).createMutableAttribute(Attributes.ARMOR, 0.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.28F);
     }
 
     public boolean isBreedingItem(ItemStack stack) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySeal.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySeal.java
@@ -87,7 +87,7 @@ public class EntitySeal extends AnimalEntity implements ISemiAquatic, IHerdPanic
 
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 20.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.2F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 10.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.18F);
     }
 
     public static boolean canSealSpawn(EntityType<? extends AnimalEntity> animal, IWorld worldIn, SpawnReason reason, BlockPos pos, Random random) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityShoebill.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityShoebill.java
@@ -78,7 +78,7 @@ public class EntityShoebill extends AnimalEntity implements IAnimatedEntity, ITa
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 16D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.2F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 10D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.2F);
     }
 
     protected SoundEvent getAmbientSound() {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySnowLeopard.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySnowLeopard.java
@@ -99,7 +99,7 @@ public class EntitySnowLeopard extends AnimalEntity implements IAnimatedEntity, 
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 36D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 8.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.35F).createMutableAttribute(Attributes.FOLLOW_RANGE, 64F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 6.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.35F).createMutableAttribute(Attributes.FOLLOW_RANGE, 64F);
     }
 
     protected SoundEvent getAmbientSound() {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySoulVulture.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySoulVulture.java
@@ -98,7 +98,7 @@ public class EntitySoulVulture extends MonsterEntity implements IFlyingAnimal {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 16.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 18.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 12.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 18.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 4.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.25F);
     }
 
     public boolean isPerchBlock(BlockPos pos, BlockState state) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityStraddler.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityStraddler.java
@@ -73,7 +73,7 @@ public class EntityStraddler extends MonsterEntity implements IAnimatedEntity {
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 28.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.8D).createMutableAttribute(Attributes.ARMOR, 15.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 64.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.3F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 28.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.8D).createMutableAttribute(Attributes.ARMOR, 10.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 64.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.3F);
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityWarpedMosco.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityWarpedMosco.java
@@ -85,7 +85,7 @@ public class EntityWarpedMosco extends MonsterEntity implements IAnimatedEntity 
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 100D).createMutableAttribute(Attributes.FOLLOW_RANGE, 128.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 11.0D).createMutableAttribute(Attributes.ARMOR, 10D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 1D).createMutableAttribute(Attributes.ARMOR_TOUGHNESS, 2D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.3D);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 100D).createMutableAttribute(Attributes.FOLLOW_RANGE, 128.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 10.0D).createMutableAttribute(Attributes.ARMOR, 10D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 1D).createMutableAttribute(Attributes.ARMOR_TOUGHNESS, 2D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.3D);
     }
 
     private static Animation getRandomAttack(Random rand) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityWarpedMosco.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityWarpedMosco.java
@@ -85,7 +85,7 @@ public class EntityWarpedMosco extends MonsterEntity implements IAnimatedEntity 
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 100D).createMutableAttribute(Attributes.FOLLOW_RANGE, 128.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 9.0D).createMutableAttribute(Attributes.ARMOR, 10D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 1D).createMutableAttribute(Attributes.ARMOR_TOUGHNESS, 2D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.3D);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 100D).createMutableAttribute(Attributes.FOLLOW_RANGE, 128.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 11.0D).createMutableAttribute(Attributes.ARMOR, 10D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 1D).createMutableAttribute(Attributes.ARMOR_TOUGHNESS, 2D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.3D);
     }
 
     private static Animation getRandomAttack(Random rand) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityWarpedToad.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityWarpedToad.java
@@ -84,7 +84,7 @@ public class EntityWarpedToad extends TameableEntity implements ITargetsDroppedI
     }
 
     public static AttributeModifierMap.MutableAttribute bakeAttributes() {
-        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 3.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.25F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.35F);
+        return MonsterEntity.func_234295_eP_().createMutableAttribute(Attributes.MAX_HEALTH, 30.0D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.25F).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.35F);
     }
 
     protected SoundEvent getAmbientSound() {


### PR DESCRIPTION
This is mostly to our older mobs, but this changes some health, armor and slightly changes movement speed values of some mobs, such as:

-Crocodiles are now a bit slower when chasing things, and have 20 health
-Komodo Dragons are slightly slower, have no armor, 20hp and a little more attack damage
-Capuchins have 8hp
-Gorillas have no armor, normal ones have 20HP, Silverbacks have 40hp (hopefully i changed it properly), to make them more -like cheaper iron golems
-Removed armor from hammerheads, orcas and mosquitos
-Gazelles have 8hp instead of 16 so they're easier to kill for food
-Warped mosco's regular attack does 10 damage now, from 9 damage, very minimal, really
-Endergrades have no armor and 25hp
-Centipede hp from 60 to 30, 4 armor and slightly faster movement speed
-Hummingbird hp is now 4
-Elephants have 65hp, tusked ones have 80hp
-Grizzly bears now have 35hp, 4 attack, and are significantly slower
-Lobsters have 5hp and 2 armor
-Moose have 55hp and do 7 damage
-Mungus has 15hp
-Raccoons have 9 health and do 2 damage
-Rattlesnakes have 8hp, no armor and are slightly faster
-Seals have 10hp and are a bit slower 
-Shoebills have 10hp
-Snow leopards have 30hp and do 6 damage
-Soul vultures have 12hp, just so they're a bit easier to deal with 
-Straddlers have 10 armor so they're a bit easier to go around and farm
-Warped toad does 2 damage
-Bone serpent aggro range reduced from 64 to 32, have 25hp, and do 5 damage instead of 4 now, and are slower, though idk if this also applies to them in lava

You can freely adjust these values, or correct some stuff I messed up, this is more so our older mobs are on par with our newer ones balance-wise, i may have butchered or buffed some mobs too much but I'm not sure

Some stuff was suggested by Spinomania but i edited some of the suggested values a bit too