### PR TITLE
Prevent riding baby grizzly bears

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGrizzlyBear.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGrizzlyBear.java
@@ -228,7 +228,7 @@ public class EntityGrizzlyBear extends TameableEntity implements IAngerable, IAn
         Item item = itemstack.getItem();
         ActionResultType type = super.getEntityInteractionResult(player, hand);
         if(type != ActionResultType.SUCCESS && isTamed() && isOwner(player) && !isBreedingItem(itemstack)){
-            if(!player.isSneaking()){
+            if(!player.isSneaking() && !this.isChild()){
                 player.startRiding(this);
                 return ActionResultType.SUCCESS;
             }else{


### PR DESCRIPTION
Fixes #541

Removes the ability to ride on baby grizzly bears as other baby mobs in the game cannot be ridden on, such as llamas and pigs. Keeps the ability to make the baby bears sit. 