### PR TITLE
Fix void portal subtitle and void worm getting stuck when going to a portal

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityVoidWorm.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityVoidWorm.java
@@ -837,6 +837,7 @@ public class EntityVoidWorm extends MonsterEntity {
 
         public void tick() {
             if (EntityVoidWorm.this.portalTarget != null) {
+                noClip = true;
                 AxisAlignedBB bb = EntityVoidWorm.this.portalTarget.getBoundingBox();
                 double centerX = bb.minX + ((bb.maxX - bb.minX) / 2F);
                 double centerY = bb.minY + ((bb.maxY - bb.minY) / 2F);
@@ -845,6 +846,10 @@ public class EntityVoidWorm extends MonsterEntity {
                 EntityVoidWorm.this.setMotion(EntityVoidWorm.this.getMotion().add(Math.signum(centerX - EntityVoidWorm.this.getPosX()) * sped, Math.signum(centerY - EntityVoidWorm.this.getPosY()) * sped, Math.signum(centerZ - EntityVoidWorm.this.getPosZ()) * sped));
                 EntityVoidWorm.this.getMoveHelper().setMoveTo(centerX, centerY, centerZ, 1);
             }
+        }
+
+        public void resetTask() {
+            noClip = false;
         }
     }
 

--- a/src/main/resources/assets/alexsmobs/lang/en_us.json
+++ b/src/main/resources/assets/alexsmobs/lang/en_us.json
@@ -430,7 +430,7 @@
   "alexsmobs.sound.subtitle.void_worm_idle": "Void Worm roars",
   "alexsmobs.sound.subtitle.void_worm_hurt": "Void Worm hisses",
   "alexsmobs.sound.subtitle.void_portal_open": "Void Portal opens",
-  "alexsmobs.sound.subtitle.void_portal_closes": "Void Portal closes",
+  "alexsmobs.sound.subtitle.void_portal_close": "Void Portal closes",
   "alexsmobs.sound.subtitle.mimic_octopus_idle": "Mimic Octopus squeaks",
   "alexsmobs.sound.subtitle.mimic_octopus_hurt": "Mimic Octopus squishes",
   "alexsmobs.sound.subtitle.music_disc.daze": "Daze",

--- a/src/main/resources/assets/alexsmobs/lang/es_es.json
+++ b/src/main/resources/assets/alexsmobs/lang/es_es.json
@@ -429,7 +429,7 @@
   "alexsmobs.sound.subtitle.void_worm_idle": "El gusano del vacío ruge",
   "alexsmobs.sound.subtitle.void_worm_hurt": "El gusano del vacío silba",
   "alexsmobs.sound.subtitle.void_portal_open": "Se abre el portal del vacío",
-  "alexsmobs.sound.subtitle.void_portal_closes": "El portal del vacío se cierra",
+  "alexsmobs.sound.subtitle.void_portal_close": "El portal del vacío se cierra",
   "alexsmobs.sound.subtitle.mimic_octopus_idle": "Chirridos de pulpo mímico",
   "alexsmobs.sound.subtitle.mimic_octopus_hurt": "Ssquishes de pulpo mímico",
   "alexsmobs.sound.subtitle.music_disc.daze": "Aturdimiento",

--- a/src/main/resources/assets/alexsmobs/lang/sv_se.json
+++ b/src/main/resources/assets/alexsmobs/lang/sv_se.json
@@ -429,7 +429,7 @@
   "alexsmobs.sound.subtitle.void_worm_idle": "Tomhetsmask ryter",
   "alexsmobs.sound.subtitle.void_worm_hurt": "Tomhetsmask väser",
   "alexsmobs.sound.subtitle.void_portal_open": "Tomhetsportal öppnas",
-  "alexsmobs.sound.subtitle.void_portal_closes": "Tomhetsportal stängs",
+  "alexsmobs.sound.subtitle.void_portal_close": "Tomhetsportal stängs",
   "alexsmobs.sound.subtitle.mimic_octopus_idle": "Härmande bläckfisk piper",
   "alexsmobs.sound.subtitle.mimic_octopus_hurt": "Härmande bläckfisk klafsar",
   "alexsmobs.sound.subtitle.music_disc.daze": "Daze",

--- a/src/main/resources/assets/alexsmobs/lang/zh_cn.json
+++ b/src/main/resources/assets/alexsmobs/lang/zh_cn.json
@@ -429,7 +429,7 @@
   "alexsmobs.sound.subtitle.void_worm_idle": "虚空蠕虫：低鸣",
   "alexsmobs.sound.subtitle.void_worm_hurt": "虚空蠕虫：嘶嘶声",
   "alexsmobs.sound.subtitle.void_portal_open": "虚空传送门：打开",
-  "alexsmobs.sound.subtitle.void_portal_closes": "虚空传送门：关闭",
+  "alexsmobs.sound.subtitle.void_portal_close": "虚空传送门：关闭",
   "alexsmobs.sound.subtitle.mimic_octopus_idle": "拟态章鱼：尖叫声",
   "alexsmobs.sound.subtitle.mimic_octopus_hurt": "拟态章鱼：吧唧声",
   "alexsmobs.sound.subtitle.music_disc.daze": "Daze",


### PR DESCRIPTION
Fix #503

Turns on the void worm's no clip when trying to go toward a portal, otherwise it would be very easy to block the portal before the void worm gets to it and have it stuck there forever (or until hit), but with no clip the void worm will not be stuck when trying to get to a portal.