### PR TITLE
Laviathan Spyglass Advancement Fix

### DIFF
--- a/src/main/resources/data/alexsmobs/advancements/alexsmobs/laviathan_spyglass.json
+++ b/src/main/resources/data/alexsmobs/advancements/alexsmobs/laviathan_spyglass.json
@@ -8,7 +8,7 @@
       "translate": "advancements.alexsmobs.laviathan_spyglass.title"
     },
     "description": {
-      "translate": "advancements.alexsmobs.laviathan_spyglass.description"
+      "translate": "advancements.alexsmobs.laviathan_spyglass.desc"
     },
     "frame": "challenge",
     "show_toast": true,


### PR DESCRIPTION
Fixes the current bug with the laviathan advancement description not showing.