### PR TITLE
(1.18) Clean-up and optimise ServerEvents

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
@@ -165,10 +165,10 @@ public class ServerEvents {
             BeachedCachalotWhaleSpawner spawner = BEACHED_CACHALOT_WHALE_SPAWNER_MAP.get(serverWorld);
             spawner.tick();
 
-			for (final var trip : teleportPlayers) {
-				ServerPlayer player = trip.a;
-				ServerLevel endpointWorld = trip.b;
-				BlockPos endpoint = trip.c;
+			for (final var triple : teleportPlayers) {
+				ServerPlayer player = triple.a;
+				ServerLevel endpointWorld = triple.b;
+				BlockPos endpoint = triple.c;
                 player.teleportTo(endpointWorld, endpoint.getX() + 0.5D, endpoint.getY() + 0.5D, endpoint.getZ() + 0.5D, player.getYRot(), player.getXRot());
                 ChunkPos chunkpos = new ChunkPos(endpoint);
                 endpointWorld.getChunkSource().addRegionTicket(TicketType.POST_TELEPORT, chunkpos, 1, player.getId());
@@ -183,13 +183,13 @@ public class ServerEvents {
     }
 
     protected static BlockHitResult rayTrace(Level worldIn, Player player, ClipContext.Fluid fluidMode) {
-        float f = player.getXRot();
-        float f1 = player.getYRot();
+        float x = player.getXRot();
+        float y = player.getYRot();
         Vec3 vector3d = player.getEyePosition(1.0F);
-        float f2 = Mth.cos(-f1 * ((float) Math.PI / 180F) - (float) Math.PI);
-        float f3 = Mth.sin(-f1 * ((float) Math.PI / 180F) - (float) Math.PI);
-        float f4 = -Mth.cos(-f * ((float) Math.PI / 180F));
-        float f5 = Mth.sin(-f * ((float) Math.PI / 180F));
+        float f2 = Mth.cos(-y * ((float) Math.PI / 180F) - (float) Math.PI);
+        float f3 = Mth.sin(-y * ((float) Math.PI / 180F) - (float) Math.PI);
+        float f4 = -Mth.cos(-x * ((float) Math.PI / 180F));
+        float f5 = Mth.sin(-x * ((float) Math.PI / 180F));
         float f6 = f3 * f4;
         float f7 = f2 * f4;
         double d0 = player.getAttribute(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).getValue();
@@ -321,9 +321,9 @@ public class ServerEvents {
     public void onTradeSetup(VillagerTradesEvent event) {
         if (event.getType() == VillagerProfession.FISHERMAN) {
             VillagerTrades.ItemListing ambergrisTrade = new EmeraldsForItemsTrade(AMItemRegistry.AMBERGRIS.get(), 20, 3, 4);
-			final var l = event.getTrades().get(2);
-            l.add(ambergrisTrade);
-            event.getTrades().put(2, l);
+			final var list = event.getTrades().get(2);
+            list.add(ambergrisTrade);
+            event.getTrades().put(2, list);
         }
     }
 
@@ -376,19 +376,20 @@ public class ServerEvents {
             }
         }
         if (event.getItemStack().getItem() == Items.GLASS_BOTTLE && AMConfig.lavaBottleEnabled) {
-            HitResult raytraceresult = rayTrace(event.getWorld(), event.getPlayer(), ClipContext.Fluid.SOURCE_ONLY);
+            final var player = event.getPlayer();
+            HitResult raytraceresult = rayTrace(event.getWorld(), player, ClipContext.Fluid.SOURCE_ONLY);
             if (raytraceresult.getType() == HitResult.Type.BLOCK) {
                 BlockPos blockpos = ((BlockHitResult) raytraceresult).getBlockPos();
-                if (event.getWorld().mayInteract(event.getPlayer(), blockpos)) {
+                if (event.getWorld().mayInteract(player, blockpos)) {
                     if (event.getWorld().getFluidState(blockpos).is(FluidTags.LAVA)) {
-                        event.getWorld().playSound(event.getPlayer(), event.getPlayer().getX(), event.getPlayer().getY(), event.getPlayer().getZ(), SoundEvents.BOTTLE_FILL, SoundSource.NEUTRAL, 1.0F, 1.0F);
-                        event.getPlayer().awardStat(Stats.ITEM_USED.get(Items.GLASS_BOTTLE));
-                        event.getPlayer().setSecondsOnFire(6);
-                        if (!event.getPlayer().addItem(new ItemStack(AMItemRegistry.LAVA_BOTTLE.get()))) {
-                            event.getPlayer().spawnAtLocation(new ItemStack(AMItemRegistry.LAVA_BOTTLE.get()));
+                        event.getWorld().playSound(player, player.getX(), player.getY(), player.getZ(), SoundEvents.BOTTLE_FILL, SoundSource.NEUTRAL, 1.0F, 1.0F);
+                        player.awardStat(Stats.ITEM_USED.get(Items.GLASS_BOTTLE));
+                        player.setSecondsOnFire(6);
+                        if (!player.addItem(new ItemStack(AMItemRegistry.LAVA_BOTTLE.get()))) {
+                            player.spawnAtLocation(new ItemStack(AMItemRegistry.LAVA_BOTTLE.get()));
                         }
-                        event.getPlayer().swing(event.getHand());
-                        if (!event.getPlayer().isCreative()) {
+                        player.swing(event.getHand());
+                        if (!player.isCreative()) {
                             event.getItemStack().shrink(1);
                         }
                     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
@@ -535,27 +535,27 @@ public class ServerEvents {
 				spider.targetSelector.addGoal(4,
 						new NearestAttackableTargetGoal<>(spider, EntityFly.class, 1, true, false, null));
             }
-			if (event.getEntity() instanceof final Wolf wolf && AMConfig.wolvesAttackMoose) {
+			else if (event.getEntity() instanceof final Wolf wolf && AMConfig.wolvesAttackMoose) {
 				wolf.targetSelector.addGoal(6, new NonTameRandomTargetGoal<>(wolf, EntityMoose.class, false, null));
             }
-			if (event.getEntity() instanceof final PolarBear bear && AMConfig.polarBearsAttackSeals) {
+            else if (event.getEntity() instanceof final PolarBear bear && AMConfig.polarBearsAttackSeals) {
 				bear.targetSelector.addGoal(6,
 						new NearestAttackableTargetGoal<>(bear, EntitySeal.class, 15, true, true, null));
             }
-			if (event.getEntity() instanceof final Creeper creeper) {
+            else if (event.getEntity() instanceof final Creeper creeper) {
                 creeper.targetSelector.addGoal(3, new AvoidEntityGoal<>(creeper, EntitySnowLeopard.class, 6.0F, 1.0D, 1.2D));
                 creeper.targetSelector.addGoal(3, new AvoidEntityGoal<>(creeper, EntityTiger.class, 6.0F, 1.0D, 1.2D));
             }
-			if ((event.getEntity() instanceof Fox || event.getEntity() instanceof Cat
+            else if ((event.getEntity() instanceof Fox || event.getEntity() instanceof Cat
 					|| event.getEntity() instanceof Ocelot) && AMConfig.catsAndFoxesAttackJerboas) {
                 Mob mb = (Mob) event.getEntity();
 				mb.targetSelector.addGoal(6,
 						new NearestAttackableTargetGoal<>(mb, EntityJerboa.class, 45, true, true, null));
             }
-			if (event.getEntity() instanceof final Rabbit rabbit && AMConfig.bunfungusTransformation) {
+            else if (event.getEntity() instanceof final Rabbit rabbit && AMConfig.bunfungusTransformation) {
                 rabbit.goalSelector.addGoal(3, new TemptGoal(rabbit, 1.0D, Ingredient.of(AMItemRegistry.MUNGAL_SPORES.get()), false));
             }
-			if (event.getEntity() instanceof final Dolphin dolphin && AMConfig.dolphinsAttackFlyingFish) {
+            else if (event.getEntity() instanceof final Dolphin dolphin && AMConfig.dolphinsAttackFlyingFish) {
 				dolphin.targetSelector.addGoal(2,
 						new NearestAttackableTargetGoal<>(dolphin, EntityFlyingFish.class, 70, true, true, null));
             }
@@ -651,7 +651,7 @@ public class ServerEvents {
 			final var attributes = event.getEntityLiving().getAttribute(Attributes.MOVEMENT_SPEED);
 			if (player.getItemBySlot(EquipmentSlot.FEET).getItem() == AMItemRegistry.ROADDRUNNER_BOOTS.get()
 					|| attributes.hasModifier(SAND_SPEED_BONUS)) {
-				boolean sand = player.level.getBlockState(getDownPos(player.blockPosition(), player.level))
+				final boolean sand = player.level.getBlockState(getDownPos(player.blockPosition(), player.level))
 						.is(BlockTags.SAND);
 				if (sand && !attributes.hasModifier(SAND_SPEED_BONUS)) {
 					attributes.addPermanentModifier(SAND_SPEED_BONUS);
@@ -697,12 +697,9 @@ public class ServerEvents {
             if (event.getEntityLiving().horizontalCollision && !event.getEntityLiving().isInWater()) {
                 event.getEntityLiving().fallDistance = 0.0F;
                 Vec3 motion = event.getEntityLiving().getDeltaMovement();
-                double d0 = Mth.clamp(motion.x, -0.15F, 0.15F);
-                double d1 = Mth.clamp(motion.z, -0.15F, 0.15F);
-                double d2 = 0.1D;
-                if (d2 < 0.0D && !event.getEntityLiving().getFeetBlockState().isScaffolding(event.getEntityLiving()) && event.getEntityLiving().isSuppressingSlidingDownLadder()) {
-                    d2 = 0.0D;
-                }
+                final double d0 = Mth.clamp(motion.x, -0.15F, 0.15F);
+                final double d1 = Mth.clamp(motion.z, -0.15F, 0.15F);
+                final double d2 = 0.0D;
                 motion = new Vec3(d0, d2, d1);
                 event.getEntityLiving().setDeltaMovement(motion);
             }
@@ -710,7 +707,7 @@ public class ServerEvents {
         if (event.getEntityLiving().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SOMBRERO.get() && !event.getEntityLiving().level.isClientSide && AlexsMobs.isAprilFools() && event.getEntityLiving().isInWaterOrBubble()) {
             Random random = event.getEntityLiving().getRandom();
 			if (random.nextInt(245) == 0 && !EntitySeaBear.isMobSafe(event.getEntityLiving())) {
-                int dist = 32;
+                final int dist = 32;
 				final var nearbySeabears = event.getEntityLiving().level.getEntitiesOfClass(EntitySeaBear.class,
 						event.getEntityLiving().getBoundingBox().inflate(dist, dist, dist));
 				if (nearbySeabears.isEmpty()) {
@@ -718,8 +715,8 @@ public class ServerEvents {
 					final BlockPos at = event.getEntityLiving().blockPosition();
                     BlockPos farOff = null;
 					for (int i = 0; i < 15; i++) {
-						int f1 = (int) Math.signum(random.nextInt() - 0.5F);
-						int f2 = (int) Math.signum(random.nextInt() - 0.5F);
+						final int f1 = (int) Math.signum(random.nextInt() - 0.5F);
+                        final int f2 = (int) Math.signum(random.nextInt() - 0.5F);
 						final BlockPos pos1 = at.offset(f1 * (10 + random.nextInt(dist - 10)), random.nextInt(1),
 								f2 * (10 + random.nextInt(dist - 10)));
 						if (event.getEntityLiving().level.isWaterAt(pos1)) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
@@ -154,21 +154,21 @@ public class ServerEvents {
     private static final UUID SNEAK_SPEED_MODIFIER = UUID.fromString("7E0292F2-9434-48D5-A29F-9583AF7DF28F");
     private static final AttributeModifier SAND_SPEED_BONUS = new AttributeModifier(SAND_SPEED_MODIFIER, "roadrunner speed bonus", 0.1F, AttributeModifier.Operation.ADDITION);
     private static final AttributeModifier SNEAK_SPEED_BONUS = new AttributeModifier(SNEAK_SPEED_MODIFIER, "frontier cap speed bonus", 0.1F, AttributeModifier.Operation.ADDITION);
-	private static final Map<ServerLevel, BeachedCachalotWhaleSpawner> BEACHED_CACHALOT_WHALE_SPAWNER_MAP = new HashMap<>();
+    private static final Map<ServerLevel, BeachedCachalotWhaleSpawner> BEACHED_CACHALOT_WHALE_SPAWNER_MAP = new HashMap<>();
     public static List<Triple<ServerPlayer, ServerLevel, BlockPos>> teleportPlayers = new ArrayList<>();
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.WorldTickEvent tick) {
-		if (!tick.world.isClientSide && tick.world instanceof ServerLevel serverWorld) {
-			BEACHED_CACHALOT_WHALE_SPAWNER_MAP.computeIfAbsent(serverWorld,
-					k -> new BeachedCachalotWhaleSpawner(serverWorld));
+        if (!tick.world.isClientSide && tick.world instanceof ServerLevel serverWorld) {
+            BEACHED_CACHALOT_WHALE_SPAWNER_MAP.computeIfAbsent(serverWorld,
+                k -> new BeachedCachalotWhaleSpawner(serverWorld));
             BeachedCachalotWhaleSpawner spawner = BEACHED_CACHALOT_WHALE_SPAWNER_MAP.get(serverWorld);
             spawner.tick();
 
-			for (final var triple : teleportPlayers) {
-				ServerPlayer player = triple.a;
-				ServerLevel endpointWorld = triple.b;
-				BlockPos endpoint = triple.c;
+            for (final var triple : teleportPlayers) {
+                ServerPlayer player = triple.a;
+                ServerLevel endpointWorld = triple.b;
+                BlockPos endpoint = triple.c;
                 player.teleportTo(endpointWorld, endpoint.getX() + 0.5D, endpoint.getY() + 0.5D, endpoint.getZ() + 0.5D, player.getYRot(), player.getXRot());
                 ChunkPos chunkpos = new ChunkPos(endpoint);
                 endpointWorld.getChunkSource().addRegionTicket(TicketType.POST_TELEPORT, chunkpos, 1, player.getId());
@@ -177,7 +177,7 @@ public class ServerEvents {
             teleportPlayers.clear();
         }
         AMWorldData data = AMWorldData.get(tick.world);
-		if (data != null) {
+        if (data != null) {
             data.tickPupfish();
         }
     }
@@ -193,30 +193,30 @@ public class ServerEvents {
         final float f6 = f3 * f4;
         final float f7 = f2 * f4;
         final double d0 = player.getAttribute(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).getValue();
-		Vec3 vector3d1 = vector3d.add(f6 * d0, f5 * d0, f7 * d0);
+        Vec3 vector3d1 = vector3d.add(f6 * d0, f5 * d0, f7 * d0);
         return worldIn.clip(new ClipContext(vector3d, vector3d1, ClipContext.Block.OUTLINE, fluidMode, player));
     }
 
 
-	private static final Random RAND = new Random();
+    private static final Random RAND = new Random();
 
     @SubscribeEvent
     public static void onItemUseLast(LivingEntityUseItemEvent.Finish event) {
-		if (event.getItem().getItem() == Items.CHORUS_FRUIT && RAND.nextInt(3) == 0
-				&& event.getEntityLiving().hasEffect(AMEffectRegistry.ENDER_FLU)) {
+        if (event.getItem().getItem() == Items.CHORUS_FRUIT && RAND.nextInt(3) == 0
+            && event.getEntityLiving().hasEffect(AMEffectRegistry.ENDER_FLU)) {
             event.getEntityLiving().removeEffect(AMEffectRegistry.ENDER_FLU);
         }
     }
 
     @SubscribeEvent
     public static void onEntityResize(EntityEvent.Size event) {
-		if (event.getEntity() instanceof Player entity) {
-			final var potions = entity.getActiveEffectsMap();
-			if (event.getEntity().level != null && potions != null && !potions.isEmpty()
-					&& potions.containsKey(AMEffectRegistry.CLINGING)) {
-				if (EffectClinging.isUpsideDown(entity)) {
-					float minus = event.getOldSize().height - event.getOldEyeHeight();
-					event.setNewEyeHeight(minus);
+        if (event.getEntity() instanceof Player entity) {
+            final var potions = entity.getActiveEffectsMap();
+            if (event.getEntity().level != null && potions != null && !potions.isEmpty()
+                && potions.containsKey(AMEffectRegistry.CLINGING)) {
+                if (EffectClinging.isUpsideDown(entity)) {
+                    float minus = event.getOldSize().height - event.getOldEyeHeight();
+                    event.setNewEyeHeight(minus);
                 }
             }
         }
@@ -230,8 +230,8 @@ public class ServerEvents {
             CompoundTag data = playerData.getCompound(Player.PERSISTED_NBT_TAG);
             if (data != null && !data.getBoolean("alexsmobs_has_book")) {
                 ItemHandlerHelper.giveItemToPlayer(event.getPlayer(), new ItemStack(AMItemRegistry.ANIMAL_DICTIONARY.get()));
-				if (Objects.equals(event.getPlayer().getUUID(), ALEX_UUID)
-						|| Objects.equals(event.getPlayer().getUUID(), CARRO_UUID)) {
+                if (Objects.equals(event.getPlayer().getUUID(), ALEX_UUID)
+                    || Objects.equals(event.getPlayer().getUUID(), CARRO_UUID)) {
                     ItemHandlerHelper.giveItemToPlayer(event.getPlayer(), new ItemStack(AMItemRegistry.BEAR_DUST.get()));
                 }
                 data.putBoolean("alexsmobs_has_book", true);
@@ -245,7 +245,7 @@ public class ServerEvents {
         ItemFalconryGlove.onLeftClick(event.getPlayer(), event.getPlayer().getOffhandItem());
         ItemFalconryGlove.onLeftClick(event.getPlayer(), event.getPlayer().getMainHandItem());
         if (event.getWorld().isClientSide) {
-			AlexsMobs.sendMSGToServer(MessageSwingArm.INSTANCE);
+            AlexsMobs.sendMSGToServer(MessageSwingArm.INSTANCE);
         }
     }
 
@@ -270,11 +270,11 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onProjectileHit(ProjectileImpactEvent event) {
-		if (event.getRayTraceResult() instanceof EntityHitResult hitResult
-				&& hitResult.getEntity() instanceof EntityEmu emu && !event.getEntity().level.isClientSide) {
-			if (event.getEntity() instanceof AbstractArrow arrow) {
+        if (event.getRayTraceResult() instanceof EntityHitResult hitResult
+            && hitResult.getEntity() instanceof EntityEmu emu && !event.getEntity().level.isClientSide) {
+            if (event.getEntity() instanceof AbstractArrow arrow) {
                 //fixes soft crash with vanilla
-				arrow.setPierceLevel((byte) 0);
+                arrow.setPierceLevel((byte) 0);
             }
             if ((emu.getAnimation() == EntityEmu.ANIMATION_DODGE_RIGHT || emu.getAnimation() == EntityEmu.ANIMATION_DODGE_LEFT) && emu.getAnimationTick() < 7) {
                 event.setCanceled(true);
@@ -298,9 +298,9 @@ public class ServerEvents {
                     emu.move(MoverType.SELF, new Vec3(vector3d2.x() * 0.25F, 0.1F, vector3d2.z() * 0.25F));
                 }
                 if (!event.getEntity().level.isClientSide) {
-					if (event.getEntity() instanceof Projectile projectile) {
-						if (projectile.getOwner() instanceof ServerPlayer serverPlayer) {
-							AMAdvancementTriggerRegistry.EMU_DODGE.trigger(serverPlayer);
+                    if (event.getEntity() instanceof Projectile projectile) {
+                        if (projectile.getOwner() instanceof ServerPlayer serverPlayer) {
+                            AMAdvancementTriggerRegistry.EMU_DODGE.trigger(serverPlayer);
                         }
                     }
                 }
@@ -321,7 +321,7 @@ public class ServerEvents {
     public void onTradeSetup(VillagerTradesEvent event) {
         if (event.getType() == VillagerProfession.FISHERMAN) {
             VillagerTrades.ItemListing ambergrisTrade = new EmeraldsForItemsTrade(AMItemRegistry.AMBERGRIS.get(), 20, 3, 4);
-			final var list = event.getTrades().get(2);
+            final var list = event.getTrades().get(2);
             list.add(ambergrisTrade);
             event.getTrades().put(2, list);
         }
@@ -357,7 +357,7 @@ public class ServerEvents {
     public void onLootLevelEvent(LootingLevelEvent event) {
         DamageSource src = event.getDamageSource();
         if (src != null) {
-			if (src.getEntity() instanceof EntitySnowLeopard) {
+            if (src.getEntity() instanceof EntitySnowLeopard) {
                 event.setLootingLevel(event.getLootingLevel() + 2);
             }
         }
@@ -367,9 +367,8 @@ public class ServerEvents {
     @SubscribeEvent
     public void onUseItem(PlayerInteractEvent.RightClickItem event) {
         final var player = event.getPlayer();
-		if (event.getItemStack().getItem() == Items.WHEAT
-				&& player.getVehicle() instanceof EntityElephant elephant) {
-			if (elephant.triggerCharge(event.getItemStack())) {
+        if (event.getItemStack().getItem() == Items.WHEAT && player.getVehicle() instanceof EntityElephant elephant) {
+            if (elephant.triggerCharge(event.getItemStack())) {
                 player.swing(event.getHand());
                 if (!player.isCreative()) {
                     event.getItemStack().shrink(1);
@@ -400,7 +399,7 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onInteractWithEntity(PlayerInteractEvent.EntityInteract event) {
-		if (event.getTarget() instanceof LivingEntity living) {
+        if (event.getTarget() instanceof LivingEntity living) {
             if (!event.getPlayer().isShiftKeyDown() && VineLassoUtil.hasLassoData(living)) {
                 if (!event.getEntity().level.isClientSide) {
                     event.getTarget().spawnAtLocation(new ItemStack(AMItemRegistry.VINE_LASSO.get()));
@@ -483,18 +482,18 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onUseItemOnBlock(PlayerInteractEvent.RightClickBlock event) {
-		if (AlexsMobs.isAprilFools() && event.getItemStack().is(Items.STICK)
-				&& !event.getPlayer().getCooldowns().isOnCooldown(Items.STICK)) {
+        if (AlexsMobs.isAprilFools() && event.getItemStack().is(Items.STICK)
+            && !event.getPlayer().getCooldowns().isOnCooldown(Items.STICK)) {
             BlockState state = event.getPlayer().level.getBlockState(event.getPos());
             boolean flag = false;
-			if (state.is(Blocks.SAND)) {
+            if (state.is(Blocks.SAND)) {
                 flag = true;
                 event.getPlayer().getLevel().setBlockAndUpdate(event.getPos(), AMBlockRegistry.SAND_CIRCLE.get().defaultBlockState());
             } else if (state.is(Blocks.RED_SAND)) {
                 flag = true;
                 event.getPlayer().getLevel().setBlockAndUpdate(event.getPos(), AMBlockRegistry.RED_SAND_CIRCLE.get().defaultBlockState());
             }
-			if (flag) {
+            if (flag) {
                 event.setCanceled(true);
                 event.getPlayer().playSound(SoundEvents.SAND_BREAK, 1, 1);
                 event.getPlayer().getCooldowns().addCooldown(Items.STICK, 30);
@@ -513,51 +512,51 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onEntityJoinWorld(LivingSpawnEvent.SpecialSpawn event) {
-		if (event.getEntity() instanceof WanderingTrader trader && AMConfig.elephantTraderSpawnChance > 0) {
+        if (event.getEntity() instanceof WanderingTrader trader && AMConfig.elephantTraderSpawnChance > 0) {
             Biome biome = event.getWorld().getBiome(event.getEntity().blockPosition()).value();
-			if (RAND.nextFloat() <= AMConfig.elephantTraderSpawnChance
-					&& (!AMConfig.limitElephantTraderBiomes || biome.getBaseTemperature() >= 1.0F)) {
-				EntityElephant elephant = AMEntityRegistry.ELEPHANT.get().create(trader.level);
-				elephant.copyPosition(trader);
+            if (RAND.nextFloat() <= AMConfig.elephantTraderSpawnChance
+                && (!AMConfig.limitElephantTraderBiomes || biome.getBaseTemperature() >= 1.0F)) {
+                EntityElephant elephant = AMEntityRegistry.ELEPHANT.get().create(trader.level);
+                elephant.copyPosition(trader);
                 if (elephant.canSpawnWithTraderHere()) {
                     elephant.setTrader(true);
                     elephant.setChested(true);
                     if (!event.getWorld().isClientSide()) {
-						trader.level.addFreshEntity(elephant);
-						trader.startRiding(elephant, true);
+                        trader.level.addFreshEntity(elephant);
+                        trader.startRiding(elephant, true);
                     }
-					elephant.addElephantLoot(null, RAND.nextInt());
+                    elephant.addElephantLoot(null, RAND.nextInt());
                 }
             }
         }
         try {
-			if (event.getEntity() instanceof final Spider spider && AMConfig.spidersAttackFlies) {
-				spider.targetSelector.addGoal(4,
-						new NearestAttackableTargetGoal<>(spider, EntityFly.class, 1, true, false, null));
+            if (event.getEntity() instanceof final Spider spider && AMConfig.spidersAttackFlies) {
+                spider.targetSelector.addGoal(4,
+                    new NearestAttackableTargetGoal<>(spider, EntityFly.class, 1, true, false, null));
             }
-			else if (event.getEntity() instanceof final Wolf wolf && AMConfig.wolvesAttackMoose) {
-				wolf.targetSelector.addGoal(6, new NonTameRandomTargetGoal<>(wolf, EntityMoose.class, false, null));
+            else if (event.getEntity() instanceof final Wolf wolf && AMConfig.wolvesAttackMoose) {
+                wolf.targetSelector.addGoal(6, new NonTameRandomTargetGoal<>(wolf, EntityMoose.class, false, null));
             }
             else if (event.getEntity() instanceof final PolarBear bear && AMConfig.polarBearsAttackSeals) {
-				bear.targetSelector.addGoal(6,
-						new NearestAttackableTargetGoal<>(bear, EntitySeal.class, 15, true, true, null));
+                bear.targetSelector.addGoal(6,
+                    new NearestAttackableTargetGoal<>(bear, EntitySeal.class, 15, true, true, null));
             }
             else if (event.getEntity() instanceof final Creeper creeper) {
                 creeper.targetSelector.addGoal(3, new AvoidEntityGoal<>(creeper, EntitySnowLeopard.class, 6.0F, 1.0D, 1.2D));
                 creeper.targetSelector.addGoal(3, new AvoidEntityGoal<>(creeper, EntityTiger.class, 6.0F, 1.0D, 1.2D));
             }
             else if ((event.getEntity() instanceof Fox || event.getEntity() instanceof Cat
-					|| event.getEntity() instanceof Ocelot) && AMConfig.catsAndFoxesAttackJerboas) {
+                || event.getEntity() instanceof Ocelot) && AMConfig.catsAndFoxesAttackJerboas) {
                 Mob mb = (Mob) event.getEntity();
-				mb.targetSelector.addGoal(6,
-						new NearestAttackableTargetGoal<>(mb, EntityJerboa.class, 45, true, true, null));
+                mb.targetSelector.addGoal(6,
+                    new NearestAttackableTargetGoal<>(mb, EntityJerboa.class, 45, true, true, null));
             }
             else if (event.getEntity() instanceof final Rabbit rabbit && AMConfig.bunfungusTransformation) {
                 rabbit.goalSelector.addGoal(3, new TemptGoal(rabbit, 1.0D, Ingredient.of(AMItemRegistry.MUNGAL_SPORES.get()), false));
             }
             else if (event.getEntity() instanceof final Dolphin dolphin && AMConfig.dolphinsAttackFlyingFish) {
-				dolphin.targetSelector.addGoal(2,
-						new NearestAttackableTargetGoal<>(dolphin, EntityFlyingFish.class, 70, true, true, null));
+                dolphin.targetSelector.addGoal(2,
+                    new NearestAttackableTargetGoal<>(dolphin, EntityFlyingFish.class, 70, true, true, null));
             }
         } catch (Exception e) {
             AlexsMobs.LOGGER.warn("Tried to add unique behaviors to vanilla mobs and encountered an error");
@@ -566,7 +565,7 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onPlayerAttackEntityEvent(AttackEntityEvent event) {
-		if (event.getTarget() instanceof LivingEntity living) {
+        if (event.getTarget() instanceof LivingEntity living) {
             if (event.getPlayer().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.MOOSE_HEADGEAR.get()) {
                 living.knockback(1F, Mth.sin(event.getPlayer().getYRot() * ((float) Math.PI / 180F)),
                         -Mth.cos(event.getPlayer().getYRot() * ((float) Math.PI / 180F)));
@@ -587,26 +586,26 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onLivingDamageEvent(LivingDamageEvent event) {
-		if (event.getSource().getEntity() instanceof final LivingEntity attacker) {
+        if (event.getSource().getEntity() instanceof final LivingEntity attacker) {
             if (event.getAmount() > 0 && attacker.hasEffect(AMEffectRegistry.SOULSTEAL) && attacker.getEffect(AMEffectRegistry.SOULSTEAL) != null) {
                 final int level = attacker.getEffect(AMEffectRegistry.SOULSTEAL).getAmplifier() + 1;
-				if (attacker.getHealth() < attacker.getMaxHealth()
-						&& ThreadLocalRandom.current().nextFloat() < (0.25F + (level * 0.25F))) {
+                if (attacker.getHealth() < attacker.getMaxHealth()
+                    && ThreadLocalRandom.current().nextFloat() < (0.25F + (level * 0.25F))) {
                     attacker.heal(Math.min(event.getAmount() / 2F * level, 2 + 2 * level));
                 }
             }
 
-			if (event.getEntityLiving() instanceof final Player player) {
-				if (attacker instanceof final EntityMimicOctopus octupus && octupus.isOwnedBy(player)) {
-					event.setCanceled(true);
-					return;
-				}
-				if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
-					if (attacker.distanceTo(player) < attacker.getBbWidth() + player.getBbWidth() + 0.5F) {
-						attacker.hurt(DamageSource.thorns(player), 1F);
-						attacker.knockback(0.5F, Mth.sin((attacker.getYRot() + 180) * ((float) Math.PI / 180F)),
-								-Mth.cos((attacker.getYRot() + 180) * ((float) Math.PI / 180F)));
-					}
+            if (event.getEntityLiving() instanceof final Player player) {
+                if (attacker instanceof final EntityMimicOctopus octupus && octupus.isOwnedBy(player)) {
+                    event.setCanceled(true);
+                    return;
+                }
+                if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
+                    if (attacker.distanceTo(player) < attacker.getBbWidth() + player.getBbWidth() + 0.5F) {
+                        attacker.hurt(DamageSource.thorns(player), 1F);
+                        attacker.knockback(0.5F, Mth.sin((attacker.getYRot() + 180) * ((float) Math.PI / 180F)),
+                            -Mth.cos((attacker.getYRot() + 180) * ((float) Math.PI / 180F)));
+                    }
                 }
             }
         }
@@ -633,10 +632,10 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onLivingSetTargetEvent(LivingSetAttackTargetEvent event) {
-		if (event.getTarget() != null && event.getEntityLiving() instanceof Mob mob) {
-			if (mob.getMobType() == MobType.ARTHROPOD) {
+        if (event.getTarget() != null && event.getEntityLiving() instanceof Mob mob) {
+            if (mob.getMobType() == MobType.ARTHROPOD) {
                 if (event.getTarget().hasEffect(AMEffectRegistry.BUG_PHEROMONES) && event.getEntityLiving().getLastHurtByMob() != event.getTarget()) {
-					mob.setTarget(null);
+                    mob.setTarget(null);
                 }
             }
         }
@@ -644,43 +643,43 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onLivingUpdateEvent(LivingEvent.LivingUpdateEvent event) {
-		if (event.getEntityLiving() instanceof Player player) {
-			if (player.getEyeHeight() < player.getBbHeight() * 0.5D) {
-				player.refreshDimensions();
+        if (event.getEntityLiving() instanceof Player player) {
+            if (player.getEyeHeight() < player.getBbHeight() * 0.5D) {
+                player.refreshDimensions();
             }
-			final var attributes = event.getEntityLiving().getAttribute(Attributes.MOVEMENT_SPEED);
-			if (player.getItemBySlot(EquipmentSlot.FEET).getItem() == AMItemRegistry.ROADDRUNNER_BOOTS.get()
-					|| attributes.hasModifier(SAND_SPEED_BONUS)) {
-				final boolean sand = player.level.getBlockState(getDownPos(player.blockPosition(), player.level))
-						.is(BlockTags.SAND);
-				if (sand && !attributes.hasModifier(SAND_SPEED_BONUS)) {
-					attributes.addPermanentModifier(SAND_SPEED_BONUS);
+            final var attributes = event.getEntityLiving().getAttribute(Attributes.MOVEMENT_SPEED);
+            if (player.getItemBySlot(EquipmentSlot.FEET).getItem() == AMItemRegistry.ROADDRUNNER_BOOTS.get()
+                || attributes.hasModifier(SAND_SPEED_BONUS)) {
+                final boolean sand = player.level.getBlockState(getDownPos(player.blockPosition(), player.level))
+                    .is(BlockTags.SAND);
+                if (sand && !attributes.hasModifier(SAND_SPEED_BONUS)) {
+                    attributes.addPermanentModifier(SAND_SPEED_BONUS);
                 }
-				if (player.tickCount % 25 == 0
-						&& (player.getItemBySlot(EquipmentSlot.FEET).getItem() != AMItemRegistry.ROADDRUNNER_BOOTS.get()
-								|| !sand)
-						&& attributes.hasModifier(SAND_SPEED_BONUS)) {
-					attributes.removeModifier(SAND_SPEED_BONUS);
-                }
-            }
-			if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.FRONTIER_CAP.get()
-					|| attributes.hasModifier(SNEAK_SPEED_BONUS)) {
-				final var shift = player.isShiftKeyDown();
-				if (shift && !attributes.hasModifier(SNEAK_SPEED_BONUS)) {
-					attributes.addPermanentModifier(SNEAK_SPEED_BONUS);
-                }
-				if ((!shift || player.getItemBySlot(EquipmentSlot.HEAD).getItem() != AMItemRegistry.FRONTIER_CAP.get())
-						&& attributes.hasModifier(SNEAK_SPEED_BONUS)) {
-					attributes.removeModifier(SNEAK_SPEED_BONUS);
+                if (player.tickCount % 25 == 0
+                    && (player.getItemBySlot(EquipmentSlot.FEET).getItem() != AMItemRegistry.ROADDRUNNER_BOOTS.get()
+                        || !sand)
+                    && attributes.hasModifier(SAND_SPEED_BONUS)) {
+                    attributes.removeModifier(SAND_SPEED_BONUS);
                 }
             }
-			if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
-				if (!player.isEyeInFluid(FluidTags.WATER)) {
-					player.addEffect(new MobEffectInstance(MobEffects.WATER_BREATHING, 210, 0, false, false, true));
+            if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.FRONTIER_CAP.get()
+                || attributes.hasModifier(SNEAK_SPEED_BONUS)) {
+                final var shift = player.isShiftKeyDown();
+                if (shift && !attributes.hasModifier(SNEAK_SPEED_BONUS)) {
+                    attributes.addPermanentModifier(SNEAK_SPEED_BONUS);
+                }
+                if ((!shift || player.getItemBySlot(EquipmentSlot.HEAD).getItem() != AMItemRegistry.FRONTIER_CAP.get())
+                    && attributes.hasModifier(SNEAK_SPEED_BONUS)) {
+                    attributes.removeModifier(SNEAK_SPEED_BONUS);
+                }
+            }
+            if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
+                if (!player.isEyeInFluid(FluidTags.WATER)) {
+                    player.addEffect(new MobEffectInstance(MobEffects.WATER_BREATHING, 210, 0, false, false, true));
                 }
             }
         }
-		final ItemStack boots = event.getEntityLiving().getItemBySlot(EquipmentSlot.FEET);
+        final ItemStack boots = event.getEntityLiving().getItemBySlot(EquipmentSlot.FEET);
         if (!boots.isEmpty() && boots.hasTag() && boots.getOrCreateTag().contains("BisonFur") && boots.getOrCreateTag().getBoolean("BisonFur")) {
             BlockPos pos = new BlockPos(event.getEntityLiving().getX(), event.getEntity().getY() - 0.5F, event.getEntityLiving().getZ());
             if (event.getEntityLiving().level.getBlockState(pos).is(Blocks.POWDER_SNOW)) {
@@ -706,31 +705,31 @@ public class ServerEvents {
         }
         if (event.getEntityLiving().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SOMBRERO.get() && !event.getEntityLiving().level.isClientSide && AlexsMobs.isAprilFools() && event.getEntityLiving().isInWaterOrBubble()) {
             Random random = event.getEntityLiving().getRandom();
-			if (random.nextInt(245) == 0 && !EntitySeaBear.isMobSafe(event.getEntityLiving())) {
+            if (random.nextInt(245) == 0 && !EntitySeaBear.isMobSafe(event.getEntityLiving())) {
                 final int dist = 32;
-				final var nearbySeabears = event.getEntityLiving().level.getEntitiesOfClass(EntitySeaBear.class,
-						event.getEntityLiving().getBoundingBox().inflate(dist, dist, dist));
-				if (nearbySeabears.isEmpty()) {
-					final EntitySeaBear bear = AMEntityRegistry.SEA_BEAR.get().create(event.getEntityLiving().level);
-					final BlockPos at = event.getEntityLiving().blockPosition();
+                final var nearbySeabears = event.getEntityLiving().level.getEntitiesOfClass(EntitySeaBear.class,
+                    event.getEntityLiving().getBoundingBox().inflate(dist, dist, dist));
+                if (nearbySeabears.isEmpty()) {
+                    final EntitySeaBear bear = AMEntityRegistry.SEA_BEAR.get().create(event.getEntityLiving().level);
+                    final BlockPos at = event.getEntityLiving().blockPosition();
                     BlockPos farOff = null;
-					for (int i = 0; i < 15; i++) {
-						final int f1 = (int) Math.signum(random.nextInt() - 0.5F);
+                    for (int i = 0; i < 15; i++) {
+                        final int f1 = (int) Math.signum(random.nextInt() - 0.5F);
                         final int f2 = (int) Math.signum(random.nextInt() - 0.5F);
-						final BlockPos pos1 = at.offset(f1 * (10 + random.nextInt(dist - 10)), random.nextInt(1),
-								f2 * (10 + random.nextInt(dist - 10)));
-						if (event.getEntityLiving().level.isWaterAt(pos1)) {
+                        final BlockPos pos1 = at.offset(f1 * (10 + random.nextInt(dist - 10)), random.nextInt(1),
+                            f2 * (10 + random.nextInt(dist - 10)));
+                        if (event.getEntityLiving().level.isWaterAt(pos1)) {
                             farOff = pos1;
                         }
                     }
-					if (farOff != null) {
+                    if (farOff != null) {
                         bear.setPos(farOff.getX() + 0.5F, farOff.getY() + 0.5F, farOff.getZ() + 0.5F);
                         bear.setYRot(random.nextFloat() * 360F);
                         bear.setTarget(event.getEntityLiving());
                         event.getEntityLiving().level.addFreshEntity(bear);
                     }
-				} else {
-					for (EntitySeaBear bear : nearbySeabears) {
+                } else {
+                    for (EntitySeaBear bear : nearbySeabears) {
                         bear.setTarget(event.getEntityLiving());
                     }
                 }
@@ -767,11 +766,11 @@ public class ServerEvents {
     public void onLivingAttack(LivingAttackEvent event) {
         if (!event.getEntityLiving().getUseItem().isEmpty() && event.getSource() != null && event.getSource().getEntity() != null) {
             if (event.getEntityLiving().getUseItem().getItem() == AMItemRegistry.SHIELD_OF_THE_DEEP.get()) {
-				if (event.getSource().getEntity() instanceof LivingEntity living) {
+                if (event.getSource().getEntity() instanceof LivingEntity living) {
                     boolean flag = false;
-					if (living.distanceTo(event.getEntityLiving()) <= 4
-							&& !living.hasEffect(AMEffectRegistry.EXSANGUINATION)) {
-						living.addEffect(new MobEffectInstance(AMEffectRegistry.EXSANGUINATION, 60, 2));
+                    if (living.distanceTo(event.getEntityLiving()) <= 4
+                        && !living.hasEffect(AMEffectRegistry.EXSANGUINATION)) {
+                        living.addEffect(new MobEffectInstance(AMEffectRegistry.EXSANGUINATION, 60, 2));
                         flag = true;
                     }
                     if (event.getEntityLiving().isInWaterOrBubble()) {
@@ -779,8 +778,8 @@ public class ServerEvents {
                         flag = true;
                     }
                     if (flag) {
-						event.getEntityLiving().getUseItem().hurtAndBreak(1, event.getEntityLiving(),
-								player -> player.broadcastBreakEvent(event.getEntityLiving().getUsedItemHand()));
+                        event.getEntityLiving().getUseItem().hurtAndBreak(1, event.getEntityLiving(),
+                            player -> player.broadcastBreakEvent(event.getEntityLiving().getUsedItemHand()));
                     }
                 }
             }
@@ -789,20 +788,20 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onChestGenerated(LootTableLoadEvent event) {
-		if (AMConfig.addLootToChests) {
+        if (AMConfig.addLootToChests) {
             if (event.getName().equals(BuiltInLootTables.JUNGLE_TEMPLE)) {
-				final var item = LootItem.lootTableItem(AMItemRegistry.ANCIENT_DART.get()).setQuality(40).setWeight(1);
+                final var item = LootItem.lootTableItem(AMItemRegistry.ANCIENT_DART.get()).setQuality(40).setWeight(1);
                 LootPool.Builder builder = new LootPool.Builder().name("am_dart").add(item).when(LootItemRandomChanceCondition.randomChance(1f)).setRolls(UniformGenerator.between(0, 1)).setBonusRolls(UniformGenerator.between(0, 1));
                 event.getTable().addPool(builder.build());
             }
             if (event.getName().equals(BuiltInLootTables.JUNGLE_TEMPLE_DISPENSER)) {
-				final var item = LootItem.lootTableItem(AMItemRegistry.ANCIENT_DART.get()).setQuality(20).setWeight(3);
+                final var item = LootItem.lootTableItem(AMItemRegistry.ANCIENT_DART.get()).setQuality(20).setWeight(3);
                 LootPool.Builder builder = new LootPool.Builder().name("am_dart_dispenser").add(item).when(LootItemRandomChanceCondition.randomChance(1f)).setRolls(UniformGenerator.between(0, 2)).setBonusRolls(UniformGenerator.between(0, 1));
                 event.getTable().addPool(builder.build());
             }
         }
         if (event.getName().equals(BuiltInLootTables.PIGLIN_BARTERING) && AMConfig.tusklinShoesBarteringChance > 0) {
-			final var item = LootItem.lootTableItem(AMItemRegistry.PIGSHOES.get()).setQuality(5).setWeight(8);
+            final var item = LootItem.lootTableItem(AMItemRegistry.PIGSHOES.get()).setQuality(5).setWeight(8);
             LootPool.Builder builder = new LootPool.Builder().name("am_pigshoes").add(item).when(LootItemRandomChanceCondition.randomChance((float) AMConfig.tusklinShoesBarteringChance)).setRolls(ConstantValue.exactly(1));
             event.getTable().addPool(builder.build());
         }
@@ -810,8 +809,8 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onTooltip(ItemTooltipEvent event) {
-		final var tag = event.getItemStack().getOrCreateTag();
-		if (tag.contains("BisonFur") && tag.getBoolean("BisonFur")) {
+        final var tag = event.getItemStack().getOrCreateTag();
+        if (tag.contains("BisonFur") && tag.getBoolean("BisonFur")) {
             event.getToolTip().add(new TranslatableComponent("item.alexsmobs.insulated_with_fur").withStyle(ChatFormatting.AQUA));
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
@@ -183,16 +183,16 @@ public class ServerEvents {
     }
 
     protected static BlockHitResult rayTrace(Level worldIn, Player player, ClipContext.Fluid fluidMode) {
-        float x = player.getXRot();
-        float y = player.getYRot();
+        final float x = player.getXRot();
+        final float y = player.getYRot();
         Vec3 vector3d = player.getEyePosition(1.0F);
-        float f2 = Mth.cos(-y * ((float) Math.PI / 180F) - (float) Math.PI);
-        float f3 = Mth.sin(-y * ((float) Math.PI / 180F) - (float) Math.PI);
-        float f4 = -Mth.cos(-x * ((float) Math.PI / 180F));
-        float f5 = Mth.sin(-x * ((float) Math.PI / 180F));
-        float f6 = f3 * f4;
-        float f7 = f2 * f4;
-        double d0 = player.getAttribute(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).getValue();
+        final float f2 = Mth.cos(-y * ((float) Math.PI / 180F) - (float) Math.PI);
+        final float f3 = Mth.sin(-y * ((float) Math.PI / 180F) - (float) Math.PI);
+        final float f4 = -Mth.cos(-x * ((float) Math.PI / 180F));
+        final float f5 = Mth.sin(-x * ((float) Math.PI / 180F));
+        final float f6 = f3 * f4;
+        final float f7 = f2 * f4;
+        final double d0 = player.getAttribute(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).getValue();
 		Vec3 vector3d1 = vector3d.add(f6 * d0, f5 * d0, f7 * d0);
         return worldIn.clip(new ClipContext(vector3d, vector3d1, ClipContext.Block.OUTLINE, fluidMode, player));
     }
@@ -366,17 +366,17 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onUseItem(PlayerInteractEvent.RightClickItem event) {
+        final var player = event.getPlayer();
 		if (event.getItemStack().getItem() == Items.WHEAT
-				&& event.getPlayer().getVehicle() instanceof EntityElephant elephant) {
+				&& player.getVehicle() instanceof EntityElephant elephant) {
 			if (elephant.triggerCharge(event.getItemStack())) {
-                event.getPlayer().swing(event.getHand());
-                if (!event.getPlayer().isCreative()) {
+                player.swing(event.getHand());
+                if (!player.isCreative()) {
                     event.getItemStack().shrink(1);
                 }
             }
         }
         if (event.getItemStack().getItem() == Items.GLASS_BOTTLE && AMConfig.lavaBottleEnabled) {
-            final var player = event.getPlayer();
             HitResult raytraceresult = rayTrace(event.getWorld(), player, ClipContext.Fluid.SOURCE_ONLY);
             if (raytraceresult.getType() == HitResult.Type.BLOCK) {
                 BlockPos blockpos = ((BlockHitResult) raytraceresult).getBlockPos();
@@ -447,9 +447,9 @@ public class ServerEvents {
                     }
                 } else {
                     for (int i = 0; i < 2 + random.nextInt(2); i++) {
-                        double d0 = random.nextGaussian() * 0.02D;
-                        double d1 = 0.05F + random.nextGaussian() * 0.02D;
-                        double d2 = random.nextGaussian() * 0.02D;
+                        final double d0 = random.nextGaussian() * 0.02D;
+                        final double d1 = 0.05F + random.nextGaussian() * 0.02D;
+                        final double d2 = random.nextGaussian() * 0.02D;
                         event.getTarget().level.addParticle(AMParticleRegistry.BUNFUNGUS_TRANSFORMATION, event.getTarget().getRandomX(0.7F), event.getTarget().getY(0.6F), event.getTarget().getRandomZ(0.7F), d0, d1, d2);
                     }
                 }
@@ -490,8 +490,7 @@ public class ServerEvents {
 			if (state.is(Blocks.SAND)) {
                 flag = true;
                 event.getPlayer().getLevel().setBlockAndUpdate(event.getPos(), AMBlockRegistry.SAND_CIRCLE.get().defaultBlockState());
-            }
-			if (state.is(Blocks.RED_SAND)) {
+            } else if (state.is(Blocks.RED_SAND)) {
                 flag = true;
                 event.getPlayer().getLevel().setBlockAndUpdate(event.getPos(), AMBlockRegistry.RED_SAND_CIRCLE.get().defaultBlockState());
             }
@@ -569,8 +568,7 @@ public class ServerEvents {
     public void onPlayerAttackEntityEvent(AttackEntityEvent event) {
 		if (event.getTarget() instanceof LivingEntity living) {
             if (event.getPlayer().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.MOOSE_HEADGEAR.get()) {
-                final float f1 = 2.0F;
-                living.knockback(f1 * 0.5F, Mth.sin(event.getPlayer().getYRot() * ((float) Math.PI / 180F)),
+                living.knockback(1F, Mth.sin(event.getPlayer().getYRot() * ((float) Math.PI / 180F)),
                         -Mth.cos(event.getPlayer().getYRot() * ((float) Math.PI / 180F)));
             }
             if (event.getPlayer().hasEffect(AMEffectRegistry.TIGERS_BLESSING)
@@ -591,7 +589,7 @@ public class ServerEvents {
     public void onLivingDamageEvent(LivingDamageEvent event) {
 		if (event.getSource().getEntity() instanceof final LivingEntity attacker) {
             if (event.getAmount() > 0 && attacker.hasEffect(AMEffectRegistry.SOULSTEAL) && attacker.getEffect(AMEffectRegistry.SOULSTEAL) != null) {
-                int level = attacker.getEffect(AMEffectRegistry.SOULSTEAL).getAmplifier() + 1;
+                final int level = attacker.getEffect(AMEffectRegistry.SOULSTEAL).getAmplifier() + 1;
 				if (attacker.getHealth() < attacker.getMaxHealth()
 						&& ThreadLocalRandom.current().nextFloat() < (0.25F + (level * 0.25F))) {
                     attacker.heal(Math.min(event.getAmount() / 2F * level, 2 + 2 * level));
@@ -604,10 +602,9 @@ public class ServerEvents {
 					return;
 				}
 				if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
-					float f1 = 1F;
 					if (attacker.distanceTo(player) < attacker.getBbWidth() + player.getBbWidth() + 0.5F) {
 						attacker.hurt(DamageSource.thorns(player), 1F);
-						attacker.knockback(f1 * 0.5F, Mth.sin((attacker.getYRot() + 180) * ((float) Math.PI / 180F)),
+						attacker.knockback(0.5F, Mth.sin((attacker.getYRot() + 180) * ((float) Math.PI / 180F)),
 								-Mth.cos((attacker.getYRot() + 180) * ((float) Math.PI / 180F)));
 					}
                 }

--- a/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
@@ -145,9 +145,6 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.ItemHandlerHelper;
 
-@SuppressWarnings({
-		"static-method", "resource"
-})
 @Mod.EventBusSubscriber(modid = AlexsMobs.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ServerEvents {
 
@@ -402,65 +399,65 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onInteractWithEntity(PlayerInteractEvent.EntityInteract event) {
-		if (!(event.getTarget() instanceof LivingEntity living))
-			return;
-		if (!event.getPlayer().isShiftKeyDown() && VineLassoUtil.hasLassoData(living)) {
-            if (!event.getEntity().level.isClientSide) {
-                event.getTarget().spawnAtLocation(new ItemStack(AMItemRegistry.VINE_LASSO.get()));
+		if (event.getTarget() instanceof LivingEntity living) {
+            if (!event.getPlayer().isShiftKeyDown() && VineLassoUtil.hasLassoData(living)) {
+                if (!event.getEntity().level.isClientSide) {
+                    event.getTarget().spawnAtLocation(new ItemStack(AMItemRegistry.VINE_LASSO.get()));
+                }
+                VineLassoUtil.lassoTo(null, living);
+                event.setCanceled(true);
+                event.setCancellationResult(InteractionResult.SUCCESS);
             }
-			VineLassoUtil.lassoTo(null, living);
-            event.setCanceled(true);
-            event.setCancellationResult(InteractionResult.SUCCESS);
-        }
-		if (!(event.getTarget() instanceof Player) && !(event.getTarget() instanceof EntityEndergrade)
-				&& living.hasEffect(AMEffectRegistry.ENDER_FLU)) {
-            if (event.getItemStack().getItem() == Items.CHORUS_FRUIT) {
+            if (!(event.getTarget() instanceof Player) && !(event.getTarget() instanceof EntityEndergrade)
+                    && living.hasEffect(AMEffectRegistry.ENDER_FLU)) {
+                if (event.getItemStack().getItem() == Items.CHORUS_FRUIT) {
+                    if (!event.getPlayer().isCreative()) {
+                        event.getItemStack().shrink(1);
+                    }
+                    event.getTarget().playSound(SoundEvents.GENERIC_EAT, 1.0F, 0.5F + event.getPlayer().getRandom().nextFloat());
+                    if (event.getPlayer().getRandom().nextFloat() < 0.4F) {
+                        living.removeEffect(AMEffectRegistry.ENDER_FLU);
+                        Items.CHORUS_FRUIT.finishUsingItem(event.getItemStack().copy(), event.getWorld(), ((LivingEntity) event.getTarget()));
+                    }
+                    event.setCanceled(true);
+                    event.setCancellationResult(InteractionResult.SUCCESS);
+                }
+            }
+            if (RainbowUtil.getRainbowType(living) > 0 && (event.getItemStack().getItem() == Items.SPONGE)) {
+                event.setCanceled(true);
+                event.setCancellationResult(InteractionResult.SUCCESS);
+                RainbowUtil.setRainbowType(living, 0);
                 if (!event.getPlayer().isCreative()) {
                     event.getItemStack().shrink(1);
                 }
-                event.getTarget().playSound(SoundEvents.GENERIC_EAT, 1.0F, 0.5F + event.getPlayer().getRandom().nextFloat());
-                if (event.getPlayer().getRandom().nextFloat() < 0.4F) {
-					living.removeEffect(AMEffectRegistry.ENDER_FLU);
-                    Items.CHORUS_FRUIT.finishUsingItem(event.getItemStack().copy(), event.getWorld(), ((LivingEntity) event.getTarget()));
+                ItemStack wetSponge = new ItemStack(Items.WET_SPONGE);
+                if (!event.getPlayer().addItem(wetSponge)) {
+                    event.getPlayer().drop(wetSponge, true);
+                }
+            }
+            if (living instanceof Rabbit rabbit && event.getItemStack().getItem() == AMItemRegistry.MUNGAL_SPORES.get()
+                    && AMConfig.bunfungusTransformation) {
+                final var random = ThreadLocalRandom.current();
+                if (!event.getEntityLiving().level.isClientSide && random.nextFloat() < 0.15F) {
+                    final EntityBunfungus bunfungus = rabbit.convertTo(AMEntityRegistry.BUNFUNGUS.get(), true);
+                    if (bunfungus != null) {
+                        event.getPlayer().level.addFreshEntity(bunfungus);
+                        bunfungus.setTransformsIn(EntityBunfungus.MAX_TRANSFORM_TIME);
+                    }
+                } else {
+                    for (int i = 0; i < 2 + random.nextInt(2); i++) {
+                        double d0 = random.nextGaussian() * 0.02D;
+                        double d1 = 0.05F + random.nextGaussian() * 0.02D;
+                        double d2 = random.nextGaussian() * 0.02D;
+                        event.getTarget().level.addParticle(AMParticleRegistry.BUNFUNGUS_TRANSFORMATION, event.getTarget().getRandomX(0.7F), event.getTarget().getY(0.6F), event.getTarget().getRandomZ(0.7F), d0, d1, d2);
+                    }
+                }
+                if (!event.getPlayer().isCreative()) {
+                    event.getItemStack().shrink(1);
                 }
                 event.setCanceled(true);
                 event.setCancellationResult(InteractionResult.SUCCESS);
             }
-        }
-		if (RainbowUtil.getRainbowType(living) > 0 && (event.getItemStack().getItem() == Items.SPONGE)) {
-            event.setCanceled(true);
-            event.setCancellationResult(InteractionResult.SUCCESS);
-			RainbowUtil.setRainbowType(living, 0);
-            if (!event.getPlayer().isCreative()) {
-                event.getItemStack().shrink(1);
-            }
-            ItemStack wetSponge = new ItemStack(Items.WET_SPONGE);
-            if (!event.getPlayer().addItem(wetSponge)) {
-                event.getPlayer().drop(wetSponge, true);
-            }
-        }
-		if (living instanceof Rabbit rabbit && event.getItemStack().getItem() == AMItemRegistry.MUNGAL_SPORES.get()
-				&& AMConfig.bunfungusTransformation) {
-			final var random = ThreadLocalRandom.current();
-			if (!event.getEntityLiving().level.isClientSide && random.nextFloat() < 0.15F) {
-				final EntityBunfungus bunfungus = rabbit.convertTo(AMEntityRegistry.BUNFUNGUS.get(), true);
-                if (bunfungus != null) {
-                    event.getPlayer().level.addFreshEntity(bunfungus);
-                    bunfungus.setTransformsIn(EntityBunfungus.MAX_TRANSFORM_TIME);
-                }
-            } else {
-                for (int i = 0; i < 2 + random.nextInt(2); i++) {
-                    double d0 = random.nextGaussian() * 0.02D;
-                    double d1 = 0.05F + random.nextGaussian() * 0.02D;
-                    double d2 = random.nextGaussian() * 0.02D;
-                    event.getTarget().level.addParticle(AMParticleRegistry.BUNFUNGUS_TRANSFORMATION, event.getTarget().getRandomX(0.7F), event.getTarget().getY(0.6F), event.getTarget().getRandomZ(0.7F), d0, d1, d2);
-                }
-            }
-            if (!event.getPlayer().isCreative()) {
-                event.getItemStack().shrink(1);
-            }
-            event.setCanceled(true);
-            event.setCancellationResult(InteractionResult.SUCCESS);
         }
     }
 
@@ -569,24 +566,23 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onPlayerAttackEntityEvent(AttackEntityEvent event) {
-		if (!(event.getTarget() instanceof LivingEntity living))
-			return;
-		if (event.getPlayer().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.MOOSE_HEADGEAR.get()) {
-			final float f1 = 2;
-			living.knockback(f1 * 0.5F, Mth.sin(event.getPlayer().getYRot() * ((float) Math.PI / 180F)),
-					-Mth.cos(event.getPlayer().getYRot() * ((float) Math.PI / 180F)));
-        }
-		if (event.getPlayer().hasEffect(AMEffectRegistry.TIGERS_BLESSING)
-				&& !event.getTarget().isAlliedTo(event.getPlayer()) && !(event.getTarget() instanceof EntityTiger)) {
-            AABB bb = new AABB(event.getPlayer().getX() - 32, event.getPlayer().getY() - 32, event.getPlayer().getZ() - 32, event.getPlayer().getZ() + 32, event.getPlayer().getY() + 32, event.getPlayer().getZ() + 32);
-			final var tigers = event.getPlayer().level.getEntitiesOfClass(EntityTiger.class, bb,
-					EntitySelector.ENTITY_STILL_ALIVE);
-            for (EntityTiger tiger : tigers) {
-                if (!tiger.isBaby()) {
-					tiger.setTarget(living);
+		if (event.getTarget() instanceof LivingEntity living) {
+            if (event.getPlayer().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.MOOSE_HEADGEAR.get()) {
+                final float f1 = 2.0F;
+                living.knockback(f1 * 0.5F, Mth.sin(event.getPlayer().getYRot() * ((float) Math.PI / 180F)),
+                        -Mth.cos(event.getPlayer().getYRot() * ((float) Math.PI / 180F)));
+            }
+            if (event.getPlayer().hasEffect(AMEffectRegistry.TIGERS_BLESSING)
+                    && !event.getTarget().isAlliedTo(event.getPlayer()) && !(event.getTarget() instanceof EntityTiger)) {
+                AABB bb = new AABB(event.getPlayer().getX() - 32, event.getPlayer().getY() - 32, event.getPlayer().getZ() - 32, event.getPlayer().getZ() + 32, event.getPlayer().getY() + 32, event.getPlayer().getZ() + 32);
+                final var tigers = event.getPlayer().level.getEntitiesOfClass(EntityTiger.class, bb,
+                        EntitySelector.ENTITY_STILL_ALIVE);
+                for (EntityTiger tiger : tigers) {
+                    if (!tiger.isBaby()) {
+                        tiger.setTarget(living);
+                    }
                 }
             }
-
         }
     }
 

--- a/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
@@ -1,12 +1,37 @@
 package com.github.alexthe666.alexsmobs.event;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.antlr.v4.runtime.misc.Triple;
+
 import com.github.alexthe666.alexsmobs.AlexsMobs;
 import com.github.alexthe666.alexsmobs.block.AMBlockRegistry;
 import com.github.alexthe666.alexsmobs.client.particle.AMParticleRegistry;
 import com.github.alexthe666.alexsmobs.config.AMConfig;
 import com.github.alexthe666.alexsmobs.effect.AMEffectRegistry;
 import com.github.alexthe666.alexsmobs.effect.EffectClinging;
-import com.github.alexthe666.alexsmobs.entity.*;
+import com.github.alexthe666.alexsmobs.entity.AMEntityRegistry;
+import com.github.alexthe666.alexsmobs.entity.EntityBunfungus;
+import com.github.alexthe666.alexsmobs.entity.EntityElephant;
+import com.github.alexthe666.alexsmobs.entity.EntityEmu;
+import com.github.alexthe666.alexsmobs.entity.EntityEndergrade;
+import com.github.alexthe666.alexsmobs.entity.EntityFly;
+import com.github.alexthe666.alexsmobs.entity.EntityFlyingFish;
+import com.github.alexthe666.alexsmobs.entity.EntityGiantSquid;
+import com.github.alexthe666.alexsmobs.entity.EntityJerboa;
+import com.github.alexthe666.alexsmobs.entity.EntityMimicOctopus;
+import com.github.alexthe666.alexsmobs.entity.EntityMoose;
+import com.github.alexthe666.alexsmobs.entity.EntitySeaBear;
+import com.github.alexthe666.alexsmobs.entity.EntitySeal;
+import com.github.alexthe666.alexsmobs.entity.EntitySnowLeopard;
+import com.github.alexthe666.alexsmobs.entity.EntityTiger;
 import com.github.alexthe666.alexsmobs.entity.util.FlyingFishBootsUtil;
 import com.github.alexthe666.alexsmobs.entity.util.RainbowUtil;
 import com.github.alexthe666.alexsmobs.entity.util.RockyChestplateUtil;
@@ -18,8 +43,8 @@ import com.github.alexthe666.alexsmobs.misc.AMAdvancementTriggerRegistry;
 import com.github.alexthe666.alexsmobs.misc.EmeraldsForItemsTrade;
 import com.github.alexthe666.alexsmobs.misc.ItemsForEmeraldsTrade;
 import com.github.alexthe666.alexsmobs.world.AMWorldData;
-import com.github.alexthe666.alexsmobs.world.AMWorldRegistry;
 import com.github.alexthe666.alexsmobs.world.BeachedCachalotWhaleSpawner;
+
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -28,7 +53,6 @@ import net.minecraft.network.protocol.game.ClientboundSetExperiencePacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.TicketType;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.stats.Stats;
@@ -38,29 +62,39 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
-import net.minecraft.world.entity.*;
-import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.EntitySelector;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.MobType;
+import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.AvoidEntityGoal;
 import net.minecraft.world.entity.ai.goal.TemptGoal;
 import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
 import net.minecraft.world.entity.ai.goal.target.NonTameRandomTargetGoal;
-import net.minecraft.world.entity.animal.*;
+import net.minecraft.world.entity.animal.Cat;
+import net.minecraft.world.entity.animal.Dolphin;
+import net.minecraft.world.entity.animal.Fox;
+import net.minecraft.world.entity.animal.Ocelot;
+import net.minecraft.world.entity.animal.PolarBear;
+import net.minecraft.world.entity.animal.Rabbit;
+import net.minecraft.world.entity.animal.Wolf;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.Creeper;
 import net.minecraft.world.entity.monster.Spider;
-import net.minecraft.world.entity.monster.Witch;
 import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.entity.npc.WanderingTrader;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.AbstractArrow;
-import net.minecraft.world.entity.projectile.Arrow;
-import net.minecraft.world.entity.projectile.ThrowableProjectile;
+import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -76,18 +110,29 @@ import net.minecraft.world.level.levelgen.feature.StructureFeature;
 import net.minecraft.world.level.storage.loot.BuiltInLootTables;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
-import net.minecraft.world.level.storage.loot.entries.LootPoolEntryContainer;
 import net.minecraft.world.level.storage.loot.predicates.LootItemRandomChanceCondition;
 import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
 import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
-import net.minecraft.world.phys.*;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
+
 import net.minecraftforge.client.event.FOVModifierEvent;
 import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.ProjectileImpactEvent;
-import net.minecraftforge.event.entity.living.*;
+import net.minecraftforge.event.entity.living.LivingAttackEvent;
+import net.minecraftforge.event.entity.living.LivingDamageEvent;
+import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -99,10 +144,10 @@ import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.ItemHandlerHelper;
-import org.antlr.v4.runtime.misc.Triple;
 
-import java.util.*;
-
+@SuppressWarnings({
+		"static-method", "resource"
+})
 @Mod.EventBusSubscriber(modid = AlexsMobs.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ServerEvents {
 
@@ -112,24 +157,21 @@ public class ServerEvents {
     private static final UUID SNEAK_SPEED_MODIFIER = UUID.fromString("7E0292F2-9434-48D5-A29F-9583AF7DF28F");
     private static final AttributeModifier SAND_SPEED_BONUS = new AttributeModifier(SAND_SPEED_MODIFIER, "roadrunner speed bonus", 0.1F, AttributeModifier.Operation.ADDITION);
     private static final AttributeModifier SNEAK_SPEED_BONUS = new AttributeModifier(SNEAK_SPEED_MODIFIER, "frontier cap speed bonus", 0.1F, AttributeModifier.Operation.ADDITION);
-    private static final Map<ServerLevel, BeachedCachalotWhaleSpawner> BEACHED_CACHALOT_WHALE_SPAWNER_MAP = new HashMap<ServerLevel, BeachedCachalotWhaleSpawner>();
+	private static final Map<ServerLevel, BeachedCachalotWhaleSpawner> BEACHED_CACHALOT_WHALE_SPAWNER_MAP = new HashMap<>();
     public static List<Triple<ServerPlayer, ServerLevel, BlockPos>> teleportPlayers = new ArrayList<>();
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.WorldTickEvent tick) {
-        if (!tick.world.isClientSide && tick.world instanceof ServerLevel) {
-            ServerLevel serverWorld = (ServerLevel) tick.world;
-            if (BEACHED_CACHALOT_WHALE_SPAWNER_MAP.get(serverWorld) == null) {
-                BEACHED_CACHALOT_WHALE_SPAWNER_MAP.put(serverWorld, new BeachedCachalotWhaleSpawner(serverWorld));
-            }
+		if (!tick.world.isClientSide && tick.world instanceof ServerLevel serverWorld) {
+			BEACHED_CACHALOT_WHALE_SPAWNER_MAP.computeIfAbsent(serverWorld,
+					k -> new BeachedCachalotWhaleSpawner(serverWorld));
             BeachedCachalotWhaleSpawner spawner = BEACHED_CACHALOT_WHALE_SPAWNER_MAP.get(serverWorld);
             spawner.tick();
-        }
-        if (!tick.world.isClientSide && tick.world instanceof ServerLevel) {
-            for (Triple trip : teleportPlayers) {
-                ServerPlayer player = (ServerPlayer) trip.a;
-                ServerLevel endpointWorld = (ServerLevel) trip.b;
-                BlockPos endpoint = (BlockPos) trip.c;
+
+			for (final var trip : teleportPlayers) {
+				ServerPlayer player = trip.a;
+				ServerLevel endpointWorld = trip.b;
+				BlockPos endpoint = trip.c;
                 player.teleportTo(endpointWorld, endpoint.getX() + 0.5D, endpoint.getY() + 0.5D, endpoint.getZ() + 0.5D, player.getYRot(), player.getXRot());
                 ChunkPos chunkpos = new ChunkPos(endpoint);
                 endpointWorld.getChunkSource().addRegionTicket(TicketType.POST_TELEPORT, chunkpos, 1, player.getId());
@@ -138,7 +180,7 @@ public class ServerEvents {
             teleportPlayers.clear();
         }
         AMWorldData data = AMWorldData.get(tick.world);
-        if(data != null){
+		if (data != null) {
             data.tickPupfish();
         }
     }
@@ -154,32 +196,31 @@ public class ServerEvents {
         float f6 = f3 * f4;
         float f7 = f2 * f4;
         double d0 = player.getAttribute(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).getValue();
-        Vec3 vector3d1 = vector3d.add((double) f6 * d0, (double) f5 * d0, (double) f7 * d0);
+		Vec3 vector3d1 = vector3d.add(f6 * d0, f5 * d0, f7 * d0);
         return worldIn.clip(new ClipContext(vector3d, vector3d1, ClipContext.Block.OUTLINE, fluidMode, player));
     }
 
 
+	private static final Random RAND = new Random();
+
     @SubscribeEvent
     public static void onItemUseLast(LivingEntityUseItemEvent.Finish event) {
-
-        if (event.getItem().getItem() == Items.CHORUS_FRUIT && new Random().nextInt(3) == 0 && event.getEntityLiving().hasEffect(AMEffectRegistry.ENDER_FLU)) {
+		if (event.getItem().getItem() == Items.CHORUS_FRUIT && RAND.nextInt(3) == 0
+				&& event.getEntityLiving().hasEffect(AMEffectRegistry.ENDER_FLU)) {
             event.getEntityLiving().removeEffect(AMEffectRegistry.ENDER_FLU);
         }
     }
 
     @SubscribeEvent
     public static void onEntityResize(EntityEvent.Size event) {
-        if (event.getEntity() instanceof Player) {
-            Player entity = (Player) event.getEntity();
-            try {
-                Map<MobEffect, MobEffectInstance> potions = entity.getActiveEffectsMap();
-                if (event.getEntity().level != null && potions != null && !potions.isEmpty() && potions.containsKey(AMEffectRegistry.CLINGING)) {
-                    if (EffectClinging.isUpsideDown(entity)) {
-                        float minus = event.getOldSize().height - event.getOldEyeHeight();
-                        event.setNewEyeHeight(minus);
-                    }
+		if (event.getEntity() instanceof Player entity) {
+			final var potions = entity.getActiveEffectsMap();
+			if (event.getEntity().level != null && potions != null && !potions.isEmpty()
+					&& potions.containsKey(AMEffectRegistry.CLINGING)) {
+				if (EffectClinging.isUpsideDown(entity)) {
+					float minus = event.getOldSize().height - event.getOldEyeHeight();
+					event.setNewEyeHeight(minus);
                 }
-            } catch (Exception e) {
             }
         }
 
@@ -192,7 +233,8 @@ public class ServerEvents {
             CompoundTag data = playerData.getCompound(Player.PERSISTED_NBT_TAG);
             if (data != null && !data.getBoolean("alexsmobs_has_book")) {
                 ItemHandlerHelper.giveItemToPlayer(event.getPlayer(), new ItemStack(AMItemRegistry.ANIMAL_DICTIONARY.get()));
-                if (event.getPlayer().getUUID() != null && (event.getPlayer().getUUID().equals(ALEX_UUID) || event.getPlayer().getUUID().equals(CARRO_UUID))) {
+				if (Objects.equals(event.getPlayer().getUUID(), ALEX_UUID)
+						|| Objects.equals(event.getPlayer().getUUID(), CARRO_UUID)) {
                     ItemHandlerHelper.giveItemToPlayer(event.getPlayer(), new ItemStack(AMItemRegistry.BEAR_DUST.get()));
                 }
                 data.putBoolean("alexsmobs_has_book", true);
@@ -206,7 +248,7 @@ public class ServerEvents {
         ItemFalconryGlove.onLeftClick(event.getPlayer(), event.getPlayer().getOffhandItem());
         ItemFalconryGlove.onLeftClick(event.getPlayer(), event.getPlayer().getMainHandItem());
         if (event.getWorld().isClientSide) {
-            AlexsMobs.sendMSGToServer(new MessageSwingArm());
+			AlexsMobs.sendMSGToServer(MessageSwingArm.INSTANCE);
         }
     }
 
@@ -231,11 +273,11 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onProjectileHit(ProjectileImpactEvent event) {
-        if (event.getRayTraceResult() instanceof EntityHitResult && ((EntityHitResult) event.getRayTraceResult()).getEntity() instanceof EntityEmu && !event.getEntity().level.isClientSide) {
-            EntityEmu emu = ((EntityEmu) ((EntityHitResult) event.getRayTraceResult()).getEntity());
-            if (event.getEntity() instanceof AbstractArrow) {
+		if (event.getRayTraceResult() instanceof EntityHitResult hitResult
+				&& hitResult.getEntity() instanceof EntityEmu emu && !event.getEntity().level.isClientSide) {
+			if (event.getEntity() instanceof AbstractArrow arrow) {
                 //fixes soft crash with vanilla
-                ((AbstractArrow) event.getEntity()).setPierceLevel((byte) 0);
+				arrow.setPierceLevel((byte) 0);
             }
             if ((emu.getAnimation() == EntityEmu.ANIMATION_DODGE_RIGHT || emu.getAnimation() == EntityEmu.ANIMATION_DODGE_LEFT) && emu.getAnimationTick() < 7) {
                 event.setCanceled(true);
@@ -259,21 +301,10 @@ public class ServerEvents {
                     emu.move(MoverType.SELF, new Vec3(vector3d2.x() * 0.25F, 0.1F, vector3d2.z() * 0.25F));
                 }
                 if (!event.getEntity().level.isClientSide) {
-                    ServerPlayer serverPlayerEntity = null;
-                    if (event.getEntity() instanceof Arrow) {
-                        Entity thrower = ((Arrow) event.getEntity()).getOwner();
-                        if (thrower instanceof ServerPlayer) {
-                            serverPlayerEntity = (ServerPlayer) thrower;
+					if (event.getEntity() instanceof Projectile projectile) {
+						if (projectile.getOwner() instanceof ServerPlayer serverPlayer) {
+							AMAdvancementTriggerRegistry.EMU_DODGE.trigger(serverPlayer);
                         }
-                    }
-                    if (event.getEntity() instanceof ThrowableProjectile) {
-                        Entity thrower = ((ThrowableProjectile) event.getEntity()).getOwner();
-                        if (thrower instanceof ServerPlayer) {
-                            serverPlayerEntity = (ServerPlayer) thrower;
-                        }
-                    }
-                    if (serverPlayerEntity != null) {
-                        AMAdvancementTriggerRegistry.EMU_DODGE.trigger(serverPlayerEntity);
                     }
                 }
                 emu.setDeltaMovement(emu.getDeltaMovement().add(vector3d2.x() * 0.5F, 0.32F, vector3d2.z() * 0.5F));
@@ -293,7 +324,7 @@ public class ServerEvents {
     public void onTradeSetup(VillagerTradesEvent event) {
         if (event.getType() == VillagerProfession.FISHERMAN) {
             VillagerTrades.ItemListing ambergrisTrade = new EmeraldsForItemsTrade(AMItemRegistry.AMBERGRIS.get(), 20, 3, 4);
-            List l = event.getTrades().get(2);
+			final var l = event.getTrades().get(2);
             l.add(ambergrisTrade);
             event.getTrades().put(2, l);
         }
@@ -329,8 +360,7 @@ public class ServerEvents {
     public void onLootLevelEvent(LootingLevelEvent event) {
         DamageSource src = event.getDamageSource();
         if (src != null) {
-            Entity dmgSrc = src.getEntity();
-            if (dmgSrc != null && dmgSrc instanceof EntitySnowLeopard) {
+			if (src.getEntity() instanceof EntitySnowLeopard) {
                 event.setLootingLevel(event.getLootingLevel() + 2);
             }
         }
@@ -339,8 +369,9 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onUseItem(PlayerInteractEvent.RightClickItem event) {
-        if (event.getItemStack().getItem() == Items.WHEAT && event.getPlayer().getVehicle() instanceof EntityElephant) {
-            if (((EntityElephant) event.getPlayer().getVehicle()).triggerCharge(event.getItemStack())) {
+		if (event.getItemStack().getItem() == Items.WHEAT
+				&& event.getPlayer().getVehicle() instanceof EntityElephant elephant) {
+			if (elephant.triggerCharge(event.getItemStack())) {
                 event.getPlayer().swing(event.getHand());
                 if (!event.getPlayer().isCreative()) {
                     event.getItemStack().shrink(1);
@@ -371,32 +402,35 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onInteractWithEntity(PlayerInteractEvent.EntityInteract event) {
-        if (event.getTarget() instanceof LivingEntity && !event.getPlayer().isShiftKeyDown() && VineLassoUtil.hasLassoData((LivingEntity) event.getTarget())) {
+		if (!(event.getTarget() instanceof LivingEntity living))
+			return;
+		if (!event.getPlayer().isShiftKeyDown() && VineLassoUtil.hasLassoData(living)) {
             if (!event.getEntity().level.isClientSide) {
                 event.getTarget().spawnAtLocation(new ItemStack(AMItemRegistry.VINE_LASSO.get()));
             }
-            VineLassoUtil.lassoTo(null, (LivingEntity) event.getTarget());
+			VineLassoUtil.lassoTo(null, living);
             event.setCanceled(true);
             event.setCancellationResult(InteractionResult.SUCCESS);
         }
-        if (event.getTarget() instanceof LivingEntity && !(event.getTarget() instanceof Player) && !(event.getTarget() instanceof EntityEndergrade) && ((LivingEntity) event.getTarget()).hasEffect(AMEffectRegistry.ENDER_FLU)) {
+		if (!(event.getTarget() instanceof Player) && !(event.getTarget() instanceof EntityEndergrade)
+				&& living.hasEffect(AMEffectRegistry.ENDER_FLU)) {
             if (event.getItemStack().getItem() == Items.CHORUS_FRUIT) {
                 if (!event.getPlayer().isCreative()) {
                     event.getItemStack().shrink(1);
                 }
                 event.getTarget().playSound(SoundEvents.GENERIC_EAT, 1.0F, 0.5F + event.getPlayer().getRandom().nextFloat());
                 if (event.getPlayer().getRandom().nextFloat() < 0.4F) {
-                    ((LivingEntity) event.getTarget()).removeEffect(AMEffectRegistry.ENDER_FLU);
+					living.removeEffect(AMEffectRegistry.ENDER_FLU);
                     Items.CHORUS_FRUIT.finishUsingItem(event.getItemStack().copy(), event.getWorld(), ((LivingEntity) event.getTarget()));
                 }
                 event.setCanceled(true);
                 event.setCancellationResult(InteractionResult.SUCCESS);
             }
         }
-        if (event.getTarget() instanceof LivingEntity && RainbowUtil.getRainbowType((LivingEntity) event.getTarget()) > 0 && (event.getItemStack().getItem() == Items.SPONGE)) {
+		if (RainbowUtil.getRainbowType(living) > 0 && (event.getItemStack().getItem() == Items.SPONGE)) {
             event.setCanceled(true);
             event.setCancellationResult(InteractionResult.SUCCESS);
-            RainbowUtil.setRainbowType((LivingEntity) event.getTarget(), 0);
+			RainbowUtil.setRainbowType(living, 0);
             if (!event.getPlayer().isCreative()) {
                 event.getItemStack().shrink(1);
             }
@@ -405,10 +439,11 @@ public class ServerEvents {
                 event.getPlayer().drop(wetSponge, true);
             }
         }
-        if (event.getTarget() instanceof Rabbit && event.getItemStack().getItem() == AMItemRegistry.MUNGAL_SPORES.get() && AMConfig.bunfungusTransformation) {
-            Random random = new Random();
-            if (!event.getEntityLiving().level.isClientSide && random.nextFloat() < 0.15F) {
-                EntityBunfungus bunfungus = ((Rabbit) event.getTarget()).convertTo(AMEntityRegistry.BUNFUNGUS.get(), true);
+		if (living instanceof Rabbit rabbit && event.getItemStack().getItem() == AMItemRegistry.MUNGAL_SPORES.get()
+				&& AMConfig.bunfungusTransformation) {
+			final var random = ThreadLocalRandom.current();
+			if (!event.getEntityLiving().level.isClientSide && random.nextFloat() < 0.15F) {
+				final EntityBunfungus bunfungus = rabbit.convertTo(AMEntityRegistry.BUNFUNGUS.get(), true);
                 if (bunfungus != null) {
                     event.getPlayer().level.addFreshEntity(bunfungus);
                     bunfungus.setTransformsIn(EntityBunfungus.MAX_TRANSFORM_TIME);
@@ -450,18 +485,19 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onUseItemOnBlock(PlayerInteractEvent.RightClickBlock event) {
-        if(AlexsMobs.isAprilFools() && event.getItemStack().is(Items.STICK) && !event.getPlayer().getCooldowns().isOnCooldown(Items.STICK)){
+		if (AlexsMobs.isAprilFools() && event.getItemStack().is(Items.STICK)
+				&& !event.getPlayer().getCooldowns().isOnCooldown(Items.STICK)) {
             BlockState state = event.getPlayer().level.getBlockState(event.getPos());
             boolean flag = false;
-            if(state.is(Blocks.SAND)){
+			if (state.is(Blocks.SAND)) {
                 flag = true;
                 event.getPlayer().getLevel().setBlockAndUpdate(event.getPos(), AMBlockRegistry.SAND_CIRCLE.get().defaultBlockState());
             }
-            if(state.is(Blocks.RED_SAND)){
+			if (state.is(Blocks.RED_SAND)) {
                 flag = true;
                 event.getPlayer().getLevel().setBlockAndUpdate(event.getPos(), AMBlockRegistry.RED_SAND_CIRCLE.get().defaultBlockState());
             }
-            if(flag){
+			if (flag) {
                 event.setCanceled(true);
                 event.getPlayer().playSound(SoundEvents.SAND_BREAK, 1, 1);
                 event.getPlayer().getCooldowns().addCooldown(Items.STICK, 30);
@@ -480,53 +516,51 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onEntityJoinWorld(LivingSpawnEvent.SpecialSpawn event) {
-        if (event.getEntity() instanceof WanderingTrader && AMConfig.elephantTraderSpawnChance > 0) {
-            Random rand = new Random();
+		if (event.getEntity() instanceof WanderingTrader trader && AMConfig.elephantTraderSpawnChance > 0) {
             Biome biome = event.getWorld().getBiome(event.getEntity().blockPosition()).value();
-            if (rand.nextFloat() <= AMConfig.elephantTraderSpawnChance && (!AMConfig.limitElephantTraderBiomes || biome.getBaseTemperature() >= 1.0F)) {
-                WanderingTrader traderEntity = (WanderingTrader) event.getEntity();
-                EntityElephant elephant = AMEntityRegistry.ELEPHANT.get().create(traderEntity.level);
-                elephant.copyPosition(traderEntity);
+			if (RAND.nextFloat() <= AMConfig.elephantTraderSpawnChance
+					&& (!AMConfig.limitElephantTraderBiomes || biome.getBaseTemperature() >= 1.0F)) {
+				EntityElephant elephant = AMEntityRegistry.ELEPHANT.get().create(trader.level);
+				elephant.copyPosition(trader);
                 if (elephant.canSpawnWithTraderHere()) {
                     elephant.setTrader(true);
                     elephant.setChested(true);
                     if (!event.getWorld().isClientSide()) {
-                        traderEntity.level.addFreshEntity(elephant);
-                        traderEntity.startRiding(elephant, true);
+						trader.level.addFreshEntity(elephant);
+						trader.startRiding(elephant, true);
                     }
-                    elephant.addElephantLoot(null, rand.nextInt());
+					elephant.addElephantLoot(null, RAND.nextInt());
                 }
             }
         }
         try {
-            if (event.getEntity() != null && event.getEntity() instanceof Spider && AMConfig.spidersAttackFlies) {
-                Spider spider = (Spider) event.getEntity();
-                spider.targetSelector.addGoal(4, new NearestAttackableTargetGoal(spider, EntityFly.class, 1, true, false, null));
+			if (event.getEntity() instanceof final Spider spider && AMConfig.spidersAttackFlies) {
+				spider.targetSelector.addGoal(4,
+						new NearestAttackableTargetGoal<>(spider, EntityFly.class, 1, true, false, null));
             }
-            if (event.getEntity() != null && event.getEntity() instanceof Wolf && AMConfig.wolvesAttackMoose) {
-                Wolf wolf = (Wolf) event.getEntity();
-                wolf.targetSelector.addGoal(6, new NonTameRandomTargetGoal(wolf, EntityMoose.class, false, null));
+			if (event.getEntity() instanceof final Wolf wolf && AMConfig.wolvesAttackMoose) {
+				wolf.targetSelector.addGoal(6, new NonTameRandomTargetGoal<>(wolf, EntityMoose.class, false, null));
             }
-            if (event.getEntity() != null && event.getEntity() instanceof PolarBear && AMConfig.polarBearsAttackSeals) {
-                PolarBear bear = (PolarBear) event.getEntity();
-                bear.targetSelector.addGoal(6, new NearestAttackableTargetGoal(bear, EntitySeal.class, 15, true, true, null));
+			if (event.getEntity() instanceof final PolarBear bear && AMConfig.polarBearsAttackSeals) {
+				bear.targetSelector.addGoal(6,
+						new NearestAttackableTargetGoal<>(bear, EntitySeal.class, 15, true, true, null));
             }
-            if (event.getEntity() != null && event.getEntity() instanceof Creeper) {
-                Creeper creeper = (Creeper) event.getEntity();
+			if (event.getEntity() instanceof final Creeper creeper) {
                 creeper.targetSelector.addGoal(3, new AvoidEntityGoal<>(creeper, EntitySnowLeopard.class, 6.0F, 1.0D, 1.2D));
                 creeper.targetSelector.addGoal(3, new AvoidEntityGoal<>(creeper, EntityTiger.class, 6.0F, 1.0D, 1.2D));
             }
-            if (event.getEntity() != null && (event.getEntity() instanceof Fox || event.getEntity() instanceof Cat || event.getEntity() instanceof Ocelot) && AMConfig.catsAndFoxesAttackJerboas) {
+			if ((event.getEntity() instanceof Fox || event.getEntity() instanceof Cat
+					|| event.getEntity() instanceof Ocelot) && AMConfig.catsAndFoxesAttackJerboas) {
                 Mob mb = (Mob) event.getEntity();
-                mb.targetSelector.addGoal(6, new NearestAttackableTargetGoal(mb, EntityJerboa.class, 45, true, true, null));
+				mb.targetSelector.addGoal(6,
+						new NearestAttackableTargetGoal<>(mb, EntityJerboa.class, 45, true, true, null));
             }
-            if (event.getEntity() != null && event.getEntity() instanceof Rabbit && AMConfig.bunfungusTransformation) {
-                Rabbit rabbit = (Rabbit) event.getEntity();
+			if (event.getEntity() instanceof final Rabbit rabbit && AMConfig.bunfungusTransformation) {
                 rabbit.goalSelector.addGoal(3, new TemptGoal(rabbit, 1.0D, Ingredient.of(AMItemRegistry.MUNGAL_SPORES.get()), false));
             }
-            if (event.getEntity() != null && event.getEntity() instanceof Dolphin && AMConfig.dolphinsAttackFlyingFish) {
-                Dolphin dolphin = (Dolphin) event.getEntity();
-                dolphin.targetSelector.addGoal(2, new NearestAttackableTargetGoal(dolphin, EntityFlyingFish.class, 70, true, true, null));
+			if (event.getEntity() instanceof final Dolphin dolphin && AMConfig.dolphinsAttackFlyingFish) {
+				dolphin.targetSelector.addGoal(2,
+						new NearestAttackableTargetGoal<>(dolphin, EntityFlyingFish.class, 70, true, true, null));
             }
         } catch (Exception e) {
             AlexsMobs.LOGGER.warn("Tried to add unique behaviors to vanilla mobs and encountered an error");
@@ -535,16 +569,21 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onPlayerAttackEntityEvent(AttackEntityEvent event) {
-        if (event.getPlayer().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.MOOSE_HEADGEAR.get() && event.getTarget() instanceof LivingEntity) {
-            float f1 = 2;
-            ((LivingEntity) event.getTarget()).knockback(f1 * 0.5F, Mth.sin(event.getPlayer().getYRot() * ((float) Math.PI / 180F)), -Mth.cos(event.getPlayer().getYRot() * ((float) Math.PI / 180F)));
+		if (!(event.getTarget() instanceof LivingEntity living))
+			return;
+		if (event.getPlayer().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.MOOSE_HEADGEAR.get()) {
+			final float f1 = 2;
+			living.knockback(f1 * 0.5F, Mth.sin(event.getPlayer().getYRot() * ((float) Math.PI / 180F)),
+					-Mth.cos(event.getPlayer().getYRot() * ((float) Math.PI / 180F)));
         }
-        if (event.getPlayer().hasEffect(AMEffectRegistry.TIGERS_BLESSING) && event.getTarget() instanceof LivingEntity && !event.getTarget().isAlliedTo(event.getPlayer()) && !(event.getTarget() instanceof EntityTiger)) {
+		if (event.getPlayer().hasEffect(AMEffectRegistry.TIGERS_BLESSING)
+				&& !event.getTarget().isAlliedTo(event.getPlayer()) && !(event.getTarget() instanceof EntityTiger)) {
             AABB bb = new AABB(event.getPlayer().getX() - 32, event.getPlayer().getY() - 32, event.getPlayer().getZ() - 32, event.getPlayer().getZ() + 32, event.getPlayer().getY() + 32, event.getPlayer().getZ() + 32);
-            List<EntityTiger> tigers = event.getPlayer().level.getEntitiesOfClass(EntityTiger.class, bb, EntitySelector.ENTITY_STILL_ALIVE);
+			final var tigers = event.getPlayer().level.getEntitiesOfClass(EntityTiger.class, bb,
+					EntitySelector.ENTITY_STILL_ALIVE);
             for (EntityTiger tiger : tigers) {
                 if (!tiger.isBaby()) {
-                    tiger.setTarget((LivingEntity) event.getTarget());
+					tiger.setTarget(living);
                 }
             }
 
@@ -553,28 +592,27 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onLivingDamageEvent(LivingDamageEvent event) {
-        if (event.getSource().getEntity() instanceof LivingEntity) {
-            LivingEntity attacker = (LivingEntity) event.getSource().getEntity();
+		if (event.getSource().getEntity() instanceof final LivingEntity attacker) {
             if (event.getAmount() > 0 && attacker.hasEffect(AMEffectRegistry.SOULSTEAL) && attacker.getEffect(AMEffectRegistry.SOULSTEAL) != null) {
                 int level = attacker.getEffect(AMEffectRegistry.SOULSTEAL).getAmplifier() + 1;
-                Random rand = new Random();
-                if (attacker.getHealth() < attacker.getMaxHealth() && rand.nextFloat() < (0.25F + (level * 0.25F))) {
+				if (attacker.getHealth() < attacker.getMaxHealth()
+						&& ThreadLocalRandom.current().nextFloat() < (0.25F + (level * 0.25F))) {
                     attacker.heal(Math.min(event.getAmount() / 2F * level, 2 + 2 * level));
                 }
             }
-        }
-        if (event.getEntityLiving() instanceof Player && event.getSource().getEntity() instanceof LivingEntity) {
-            LivingEntity attacker = (LivingEntity) event.getSource().getEntity();
-            Player player = (Player) event.getEntityLiving();
-            if (attacker instanceof EntityMimicOctopus && ((EntityMimicOctopus) attacker).isOwnedBy(player)) {
-                event.setCanceled(true);
-                return;
-            }
-            if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
-                float f1 = 1F;
-                if (attacker.distanceTo(player) < attacker.getBbWidth() + player.getBbWidth() + 0.5F) {
-                    attacker.hurt(DamageSource.thorns(player), 1F);
-                    attacker.knockback(f1 * 0.5F, Mth.sin((attacker.getYRot() + 180) * ((float) Math.PI / 180F)), -Mth.cos((attacker.getYRot() + 180) * ((float) Math.PI / 180F)));
+
+			if (event.getEntityLiving() instanceof final Player player) {
+				if (attacker instanceof final EntityMimicOctopus octupus && octupus.isOwnedBy(player)) {
+					event.setCanceled(true);
+					return;
+				}
+				if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
+					float f1 = 1F;
+					if (attacker.distanceTo(player) < attacker.getBbWidth() + player.getBbWidth() + 0.5F) {
+						attacker.hurt(DamageSource.thorns(player), 1F);
+						attacker.knockback(f1 * 0.5F, Mth.sin((attacker.getYRot() + 180) * ((float) Math.PI / 180F)),
+								-Mth.cos((attacker.getYRot() + 180) * ((float) Math.PI / 180F)));
+					}
                 }
             }
         }
@@ -601,10 +639,10 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onLivingSetTargetEvent(LivingSetAttackTargetEvent event) {
-        if (event.getTarget() != null && event.getEntityLiving() instanceof Mob) {
-            if (event.getEntityLiving().getMobType() == MobType.ARTHROPOD) {
+		if (event.getTarget() != null && event.getEntityLiving() instanceof Mob mob) {
+			if (mob.getMobType() == MobType.ARTHROPOD) {
                 if (event.getTarget().hasEffect(AMEffectRegistry.BUG_PHEROMONES) && event.getEntityLiving().getLastHurtByMob() != event.getTarget()) {
-                    ((Mob) event.getEntityLiving()).setTarget(null);
+					mob.setTarget(null);
                 }
             }
         }
@@ -612,35 +650,43 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onLivingUpdateEvent(LivingEvent.LivingUpdateEvent event) {
-        if (event.getEntityLiving() instanceof Player) {
-            if (event.getEntityLiving().getEyeHeight() < event.getEntityLiving().getBbHeight() * 0.5D) {
-                event.getEntityLiving().refreshDimensions();
+		if (event.getEntityLiving() instanceof Player player) {
+			if (player.getEyeHeight() < player.getBbHeight() * 0.5D) {
+				player.refreshDimensions();
             }
-            AttributeInstance modifiableattributeinstance = event.getEntityLiving().getAttribute(Attributes.MOVEMENT_SPEED);
-            if (event.getEntityLiving().getItemBySlot(EquipmentSlot.FEET).getItem() == AMItemRegistry.ROADDRUNNER_BOOTS.get() || modifiableattributeinstance.hasModifier(SAND_SPEED_BONUS)) {
-                boolean sand = event.getEntityLiving().level.getBlockState(getDownPos(event.getEntityLiving().blockPosition(), event.getEntityLiving().level)).is(BlockTags.SAND);
-                if (sand && !modifiableattributeinstance.hasModifier(SAND_SPEED_BONUS)) {
-                    modifiableattributeinstance.addPermanentModifier(SAND_SPEED_BONUS);
+			final var attributes = event.getEntityLiving().getAttribute(Attributes.MOVEMENT_SPEED);
+			if (player.getItemBySlot(EquipmentSlot.FEET).getItem() == AMItemRegistry.ROADDRUNNER_BOOTS.get()
+					|| attributes.hasModifier(SAND_SPEED_BONUS)) {
+				boolean sand = player.level.getBlockState(getDownPos(player.blockPosition(), player.level))
+						.is(BlockTags.SAND);
+				if (sand && !attributes.hasModifier(SAND_SPEED_BONUS)) {
+					attributes.addPermanentModifier(SAND_SPEED_BONUS);
                 }
-                if (event.getEntityLiving().tickCount % 25 == 0 && (event.getEntityLiving().getItemBySlot(EquipmentSlot.FEET).getItem() != AMItemRegistry.ROADDRUNNER_BOOTS.get() || !sand) && modifiableattributeinstance.hasModifier(SAND_SPEED_BONUS)) {
-                    modifiableattributeinstance.removeModifier(SAND_SPEED_BONUS);
-                }
-            }
-            if (event.getEntityLiving().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.FRONTIER_CAP.get() || modifiableattributeinstance.hasModifier(SNEAK_SPEED_BONUS)) {
-                if (event.getEntityLiving().isShiftKeyDown() && !modifiableattributeinstance.hasModifier(SNEAK_SPEED_BONUS)) {
-                    modifiableattributeinstance.addPermanentModifier(SNEAK_SPEED_BONUS);
-                }
-                if ((!event.getEntityLiving().isShiftKeyDown() || event.getEntityLiving().getItemBySlot(EquipmentSlot.HEAD).getItem() != AMItemRegistry.FRONTIER_CAP.get()) && modifiableattributeinstance.hasModifier(SNEAK_SPEED_BONUS)) {
-                    modifiableattributeinstance.removeModifier(SNEAK_SPEED_BONUS);
+				if (player.tickCount % 25 == 0
+						&& (player.getItemBySlot(EquipmentSlot.FEET).getItem() != AMItemRegistry.ROADDRUNNER_BOOTS.get()
+								|| !sand)
+						&& attributes.hasModifier(SAND_SPEED_BONUS)) {
+					attributes.removeModifier(SAND_SPEED_BONUS);
                 }
             }
-            if (event.getEntityLiving().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
-                if (!event.getEntityLiving().isEyeInFluid(FluidTags.WATER)) {
-                    event.getEntityLiving().addEffect(new MobEffectInstance(MobEffects.WATER_BREATHING, 210, 0, false, false, true));
+			if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.FRONTIER_CAP.get()
+					|| attributes.hasModifier(SNEAK_SPEED_BONUS)) {
+				final var shift = player.isShiftKeyDown();
+				if (shift && !attributes.hasModifier(SNEAK_SPEED_BONUS)) {
+					attributes.addPermanentModifier(SNEAK_SPEED_BONUS);
+                }
+				if ((!shift || player.getItemBySlot(EquipmentSlot.HEAD).getItem() != AMItemRegistry.FRONTIER_CAP.get())
+						&& attributes.hasModifier(SNEAK_SPEED_BONUS)) {
+					attributes.removeModifier(SNEAK_SPEED_BONUS);
+                }
+            }
+			if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
+				if (!player.isEyeInFluid(FluidTags.WATER)) {
+					player.addEffect(new MobEffectInstance(MobEffects.WATER_BREATHING, 210, 0, false, false, true));
                 }
             }
         }
-        ItemStack boots = event.getEntityLiving().getItemBySlot(EquipmentSlot.FEET);
+		final ItemStack boots = event.getEntityLiving().getItemBySlot(EquipmentSlot.FEET);
         if (!boots.isEmpty() && boots.hasTag() && boots.getOrCreateTag().contains("BisonFur") && boots.getOrCreateTag().getBoolean("BisonFur")) {
             BlockPos pos = new BlockPos(event.getEntityLiving().getX(), event.getEntity().getY() - 0.5F, event.getEntityLiving().getZ());
             if (event.getEntityLiving().level.getBlockState(pos).is(Blocks.POWDER_SNOW)) {
@@ -649,7 +695,6 @@ public class ServerEvents {
 
             }
             if (event.getEntityLiving().isInPowderSnow) {
-                float f = 0;
                 event.getEntityLiving().setPos(event.getEntityLiving().getX(), pos.getY() + 1, event.getEntityLiving().getZ());
             }
         }
@@ -670,30 +715,31 @@ public class ServerEvents {
         }
         if (event.getEntityLiving().getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SOMBRERO.get() && !event.getEntityLiving().level.isClientSide && AlexsMobs.isAprilFools() && event.getEntityLiving().isInWaterOrBubble()) {
             Random random = event.getEntityLiving().getRandom();
-            if(random.nextInt(245) == 0 && !EntitySeaBear.isMobSafe(event.getEntityLiving())){
+			if (random.nextInt(245) == 0 && !EntitySeaBear.isMobSafe(event.getEntityLiving())) {
                 int dist = 32;
-                List<EntitySeaBear> nearbySeabears = event.getEntityLiving().level.getEntitiesOfClass(EntitySeaBear.class, event.getEntityLiving().getBoundingBox().inflate(dist, dist, dist));
-                if(nearbySeabears.isEmpty()){
-                    EntitySeaBear bear = AMEntityRegistry.SEA_BEAR.get().create(event.getEntityLiving().level);
-                    BlockPos at = event.getEntityLiving().blockPosition();
+				final var nearbySeabears = event.getEntityLiving().level.getEntitiesOfClass(EntitySeaBear.class,
+						event.getEntityLiving().getBoundingBox().inflate(dist, dist, dist));
+				if (nearbySeabears.isEmpty()) {
+					final EntitySeaBear bear = AMEntityRegistry.SEA_BEAR.get().create(event.getEntityLiving().level);
+					final BlockPos at = event.getEntityLiving().blockPosition();
                     BlockPos farOff = null;
-                    for(int i = 0; i < 15; i++){
-                        int f1 = (int) Math.signum(random.nextFloat() - 0.5F);
-                        int f2 = (int) Math.signum(random.nextFloat() - 0.5F);
-                        BlockPos pos1 = at.offset(f1 * (10 + random.nextInt(dist - 10)), random.nextInt(1), f2 * (10 + random.nextInt(dist - 10)));
-                        BlockState state = event.getEntityLiving().getLevel().getBlockState(pos1);
-                        if(event.getEntityLiving().level.isWaterAt(pos1)){
+					for (int i = 0; i < 15; i++) {
+						int f1 = (int) Math.signum(random.nextInt() - 0.5F);
+						int f2 = (int) Math.signum(random.nextInt() - 0.5F);
+						final BlockPos pos1 = at.offset(f1 * (10 + random.nextInt(dist - 10)), random.nextInt(1),
+								f2 * (10 + random.nextInt(dist - 10)));
+						if (event.getEntityLiving().level.isWaterAt(pos1)) {
                             farOff = pos1;
                         }
                     }
-                    if(farOff != null){
+					if (farOff != null) {
                         bear.setPos(farOff.getX() + 0.5F, farOff.getY() + 0.5F, farOff.getZ() + 0.5F);
                         bear.setYRot(random.nextFloat() * 360F);
                         bear.setTarget(event.getEntityLiving());
                         event.getEntityLiving().level.addFreshEntity(bear);
                     }
-                }else{
-                    for(EntitySeaBear bear : nearbySeabears){
+				} else {
+					for (EntitySeaBear bear : nearbySeabears) {
                         bear.setTarget(event.getEntityLiving());
                     }
                 }
@@ -730,11 +776,11 @@ public class ServerEvents {
     public void onLivingAttack(LivingAttackEvent event) {
         if (!event.getEntityLiving().getUseItem().isEmpty() && event.getSource() != null && event.getSource().getEntity() != null) {
             if (event.getEntityLiving().getUseItem().getItem() == AMItemRegistry.SHIELD_OF_THE_DEEP.get()) {
-                Entity attacker = event.getSource().getEntity();
-                if (attacker instanceof LivingEntity) {
+				if (event.getSource().getEntity() instanceof LivingEntity living) {
                     boolean flag = false;
-                    if (attacker.distanceTo(event.getEntityLiving()) <= 4 && !((LivingEntity) attacker).hasEffect(AMEffectRegistry.EXSANGUINATION)) {
-                        ((LivingEntity) attacker).addEffect(new MobEffectInstance(AMEffectRegistry.EXSANGUINATION, 60, 2));
+					if (living.distanceTo(event.getEntityLiving()) <= 4
+							&& !living.hasEffect(AMEffectRegistry.EXSANGUINATION)) {
+						living.addEffect(new MobEffectInstance(AMEffectRegistry.EXSANGUINATION, 60, 2));
                         flag = true;
                     }
                     if (event.getEntityLiving().isInWaterOrBubble()) {
@@ -742,9 +788,8 @@ public class ServerEvents {
                         flag = true;
                     }
                     if (flag) {
-                        event.getEntityLiving().getUseItem().hurtAndBreak(1, event.getEntityLiving(), (playerIn) -> {
-                            playerIn.broadcastBreakEvent(event.getEntityLiving().getUsedItemHand());
-                        });
+						event.getEntityLiving().getUseItem().hurtAndBreak(1, event.getEntityLiving(),
+								player -> player.broadcastBreakEvent(event.getEntityLiving().getUsedItemHand()));
                     }
                 }
             }
@@ -753,20 +798,20 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onChestGenerated(LootTableLoadEvent event) {
-        if(AMConfig.addLootToChests){
+		if (AMConfig.addLootToChests) {
             if (event.getName().equals(BuiltInLootTables.JUNGLE_TEMPLE)) {
-                LootPoolEntryContainer.Builder item = LootItem.lootTableItem(AMItemRegistry.ANCIENT_DART.get()).setQuality(40).setWeight(1);
+				final var item = LootItem.lootTableItem(AMItemRegistry.ANCIENT_DART.get()).setQuality(40).setWeight(1);
                 LootPool.Builder builder = new LootPool.Builder().name("am_dart").add(item).when(LootItemRandomChanceCondition.randomChance(1f)).setRolls(UniformGenerator.between(0, 1)).setBonusRolls(UniformGenerator.between(0, 1));
                 event.getTable().addPool(builder.build());
             }
             if (event.getName().equals(BuiltInLootTables.JUNGLE_TEMPLE_DISPENSER)) {
-                LootPoolEntryContainer.Builder item = LootItem.lootTableItem(AMItemRegistry.ANCIENT_DART.get()).setQuality(20).setWeight(3);
+				final var item = LootItem.lootTableItem(AMItemRegistry.ANCIENT_DART.get()).setQuality(20).setWeight(3);
                 LootPool.Builder builder = new LootPool.Builder().name("am_dart_dispenser").add(item).when(LootItemRandomChanceCondition.randomChance(1f)).setRolls(UniformGenerator.between(0, 2)).setBonusRolls(UniformGenerator.between(0, 1));
                 event.getTable().addPool(builder.build());
             }
         }
         if (event.getName().equals(BuiltInLootTables.PIGLIN_BARTERING) && AMConfig.tusklinShoesBarteringChance > 0) {
-            LootPoolEntryContainer.Builder item = LootItem.lootTableItem(AMItemRegistry.PIGSHOES.get()).setQuality(5).setWeight(8);
+			final var item = LootItem.lootTableItem(AMItemRegistry.PIGSHOES.get()).setQuality(5).setWeight(8);
             LootPool.Builder builder = new LootPool.Builder().name("am_pigshoes").add(item).when(LootItemRandomChanceCondition.randomChance((float) AMConfig.tusklinShoesBarteringChance)).setRolls(ConstantValue.exactly(1));
             event.getTable().addPool(builder.build());
         }
@@ -774,7 +819,8 @@ public class ServerEvents {
 
     @SubscribeEvent
     public void onTooltip(ItemTooltipEvent event) {
-        if (event.getItemStack().hasTag() && event.getItemStack().getOrCreateTag().contains("BisonFur") && event.getItemStack().getOrCreateTag().getBoolean("BisonFur")) {
+		final var tag = event.getItemStack().getOrCreateTag();
+		if (tag.contains("BisonFur") && tag.getBoolean("BisonFur")) {
             event.getToolTip().add(new TranslatableComponent("item.alexsmobs.insulated_with_fur").withStyle(ChatFormatting.AQUA));
         }
     }

--- a/src/main/java/com/github/alexthe666/alexsmobs/message/MessageSwingArm.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/message/MessageSwingArm.java
@@ -12,19 +12,20 @@ import net.minecraftforge.network.NetworkEvent;
 
 public class MessageSwingArm {
 
-	public static final MessageSwingArm INSTANCE = new MessageSwingArm();
+    public static final MessageSwingArm INSTANCE = new MessageSwingArm();
 
-	private MessageSwingArm() {
-	}
+    private MessageSwingArm() {
+    }
 
     public static MessageSwingArm read(FriendlyByteBuf buf) {
-		return INSTANCE;
+        return INSTANCE;
     }
 
     public static void write(MessageSwingArm message, FriendlyByteBuf buf) {
     }
 
     public static class Handler {
+
         public Handler() {
         }
 

--- a/src/main/java/com/github/alexthe666/alexsmobs/message/MessageSwingArm.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/message/MessageSwingArm.java
@@ -1,21 +1,24 @@
 package com.github.alexthe666.alexsmobs.message;
 
+import java.util.function.Supplier;
+
 import com.github.alexthe666.alexsmobs.item.ItemFalconryGlove;
-import net.minecraft.world.entity.player.Player;
+
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.InteractionHand;
-import net.minecraftforge.network.NetworkEvent;
+import net.minecraft.world.entity.player.Player;
 
-import java.util.function.Supplier;
+import net.minecraftforge.network.NetworkEvent;
 
 public class MessageSwingArm {
 
-    public MessageSwingArm() {
+	public static final MessageSwingArm INSTANCE = new MessageSwingArm();
 
-    }
+	private MessageSwingArm() {
+	}
 
     public static MessageSwingArm read(FriendlyByteBuf buf) {
-        return new MessageSwingArm();
+		return INSTANCE;
     }
 
     public static void write(MessageSwingArm message, FriendlyByteBuf buf) {


### PR DESCRIPTION
This PR cleans up and optimises `ServerEvents` by:
- removing duplicate checks
- changing the instantiation of `Random` every time an event is fired with either `ThreadLocalRandom.current()` or a static `Random`
- removing unnecessary `!= null` checks, as `instanceof` checks that already.
- making local variables final, where necessary and using `var` in places for improved readability
- using new Java features ([Pattern Matching instanceof](https://docs.oracle.com/en/java/javase/16/language/pattern-matching-instanceof-operator.html))
- using `Map#computeIfAbsent` where possible

**Depends on #1046**