### PR TITLE
(1.18.X) Optimise and cleanup entities (A)

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityAnaconda.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityAnaconda.java
@@ -85,7 +85,6 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
         return AMSoundRegistry.ANACONDA_HURT;
     }
 
-
     protected void playStepSound(BlockPos pos, BlockState state) {
         if (!isBaby()) {
             this.playSound(AMSoundRegistry.ANACONDA_SLITHER, 1.0F, 1.0F);
@@ -100,7 +99,7 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
     }
 
     public static boolean canAnacondaSpawn(EntityType type, LevelAccessor worldIn, MobSpawnType reason, BlockPos pos, Random randomIn) {
-        boolean spawnBlock = worldIn.getBlockState(pos.below()).is(AMTagRegistry.ANACONDA_SPAWNS);
+        final boolean spawnBlock = worldIn.getBlockState(pos.below()).is(AMTagRegistry.ANACONDA_SPAWNS);
         return spawnBlock && pos.getY() < worldIn.getSeaLevel() + 4;
     }
 
@@ -146,8 +145,8 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
     }
 
     public InteractionResult mobInteract(Player player, InteractionHand hand) {
-        ItemStack itemstack = player.getItemInHand(hand);
-        if(isFood(itemstack)){
+        final ItemStack itemstack = player.getItemInHand(hand);
+        if (isFood(itemstack)) {
             this.setTarget(null);
         }
         return super.mobInteract(player, hand);
@@ -177,7 +176,7 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
 
 
     public void pushEntities() {
-        List<Entity> entities = this.level.getEntities(this, this.getBoundingBox().expandTowards(0.20000000298023224D, 0.0D, 0.20000000298023224D));
+        final List<Entity> entities = this.level.getEntities(this, this.getBoundingBox().expandTowards(0.2D, 0.0D, 0.2D));
         entities.stream().filter(entity -> !(entity instanceof EntityAnacondaPart) && entity.isPushable()).forEach(entity -> entity.push(this));
     }
 
@@ -209,19 +208,19 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
     }
 
     public boolean isStrangling() {
-        return this.entityData.get(STRANGLING).booleanValue();
+        return this.entityData.get(STRANGLING);
     }
 
     public void setStrangling(boolean running) {
-        this.entityData.set(STRANGLING, Boolean.valueOf(running));
+        this.entityData.set(STRANGLING, running);
     }
 
     public boolean isYellow() {
-        return this.entityData.get(YELLOW).booleanValue();
+        return this.entityData.get(YELLOW);
     }
 
     public void setYellow(boolean yellow) {
-        this.entityData.set(YELLOW, Boolean.valueOf(yellow));
+        this.entityData.set(YELLOW, yellow);
     }
 
     public int getMaxHeadXRot() {
@@ -254,40 +253,45 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
 
     public void tick() {
         super.tick();
-        if (this.isInWater() && this.isLandNavigator) {
-            switchNavigator(false);
+
+        if (this.isInWater()) {
+            if (this.isLandNavigator)
+                switchNavigator(false);
+        } else {
+            if (!this.isLandNavigator)
+                switchNavigator(true);
         }
-        if (!this.isInWater() && !this.isLandNavigator) {
-            switchNavigator(true);
-        }
+
         this.prevStrangleProgress = strangleProgress;
-        if (this.isStrangling() && strangleProgress < 5F) {
-            strangleProgress += 1;
+        if (this.isStrangling()) {
+            if (strangleProgress < 5F)
+                strangleProgress++;
+        } else {
+            if (strangleProgress > 0F)
+                strangleProgress--;
         }
-        if (!this.isStrangling() && strangleProgress > 0F) {
-            strangleProgress -= 1;
-        }
+
         this.yBodyRot = this.getYRot();
         this.yHeadRot = Mth.clamp(this.yHeadRot, this.yBodyRot - 70, this.yBodyRot + 70);
-        int segments = 7;
+
         if (this.isStrangling()) {
             if (!level.isClientSide && this.getTarget() != null && this.getTarget().isAlive()) {
                 this.setXRot(0);
-                LivingEntity e = this.getTarget();
-                float radius = this.getTarget().getBbWidth() * -0.5F;
-                float angle = (0.01745329251F * (e.yBodyRot - 45F));
-                double extraX = radius * Mth.sin((float) (Math.PI + angle));
-                double extraZ = radius * Mth.cos(angle);
-                double extraY = -0.5F;
-                this.setPosRaw(extraX + e.getX(), e.getY(1.0F), extraZ + e.getZ());
-                if(!e.isOnGround()){
-                    e.setDeltaMovement(new Vec3(0, -0.08F, 0));
-                }else{
-                    e.setDeltaMovement(Vec3.ZERO);
+                final LivingEntity target = this.getTarget();
+                final float radius = this.getTarget().getBbWidth() * -0.5F;
+                final float angle = (0.0174532925F * (target.yBodyRot - 45F));
+                final double extraX = radius * Mth.sin((float) (Math.PI + angle));
+                final double extraZ = radius * Mth.cos(angle);
+//                double extraY = -0.5F;
+                this.setPosRaw(extraX + target.getX(), target.getY(1.0F), extraZ + target.getZ());
+                if (!target.isOnGround()) {
+                    target.setDeltaMovement(new Vec3(0, -0.08F, 0));
+                } else {
+                    target.setDeltaMovement(Vec3.ZERO);
                 }
                 if (strangleTimer >= 40 && strangleTimer % 20 == 0) {
-                    double health = Mth.clamp(this.getTarget().getMaxHealth(), 4, 50);
-                    this.getTarget().hurt(DamageSource.mobAttack(this), (float)Math.max(4F, 0.25F * health));
+                    final double health = Mth.clamp(this.getTarget().getMaxHealth(), 4, 50);
+                    this.getTarget().hurt(DamageSource.mobAttack(this), (float) Math.max(4F, 0.25F * health));
                 }
                 if (this.getTarget() == null || !this.getTarget().isAlive()) {
                     strangleTimer = 0;
@@ -312,15 +316,16 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
         this.ringBuffer[this.ringBufferIndex] = this.getYRot();
 
         if (!level.isClientSide) {
-            Entity child = getChild();
+            final int segments = 7;
+            final Entity child = getChild();
             if (child == null) {
                 LivingEntity partParent = this;
                 parts = new EntityAnacondaPart[segments];
                 AnacondaPartIndex partIndex = AnacondaPartIndex.HEAD;
                 Vec3 prevPos = this.position();
                 for (int i = 0; i < segments; i++) {
-                    float prevReqRot = calcPartRotation(i) + getYawForPart(i);
-                    float reqRot = calcPartRotation(i + 1) + getYawForPart(i);
+                    final float prevReqRot = calcPartRotation(i) + getYawForPart(i);
+                    final float reqRot = calcPartRotation(i + 1) + getYawForPart(i);
                     EntityAnacondaPart part = new EntityAnacondaPart(AMEntityRegistry.ANACONDA_PART.get(), this);
                     part.setParent(partParent);
                     part.copyDataFrom(this);
@@ -351,24 +356,25 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
                     i++;
                 }
             }
-            if (!level.isClientSide) {
-                AnacondaPartIndex partIndex = AnacondaPartIndex.HEAD;
-                Vec3 prev = this.position();
-                float xRot = this.getXRot();
-                float yRot = this.getYRot();
-                float headRot = Mth.wrapDegrees(this.getYRot());
-                for (int i = 0; i < segments; i++) {
-                    if (this.parts[i] != null) {
-                        float prevReqRot = calcPartRotation(i) + getYawForPart(i);
-                        float reqRot = calcPartRotation(i + 1) + getYawForPart(i);
-                        parts[i].setStrangleProgress(this.strangleProgress);
-                        parts[i].copyDataFrom(this);
-                        prev = parts[i].tickMultipartPosition(this.getId(), partIndex, prev, xRot, prevReqRot, reqRot, true);
-                        partIndex = parts[i].getPartType();
-                        xRot = parts[i].getXRot();
-                    }
+            AnacondaPartIndex partIndex = AnacondaPartIndex.HEAD;
+            Vec3 prev = this.position();
+            float xRot = this.getXRot();
+//                float yRot = this.getYRot();
+//                float headRot = Mth.wrapDegrees(this.getYRot());
+            for (int i = 0; i < segments; i++) {
+                if (this.parts[i] != null) {
+                    final float prevReqRot = calcPartRotation(i) + getYawForPart(i);
+                    final float reqRot = calcPartRotation(i + 1) + getYawForPart(i);
+                    parts[i].setStrangleProgress(this.strangleProgress);
+                    parts[i].copyDataFrom(this);
+                    prev = parts[i].tickMultipartPosition(this.getId(), partIndex, prev, xRot, prevReqRot, reqRot, true);
+                    partIndex = parts[i].getPartType();
+                    xRot = parts[i].getXRot();
                 }
             }
+
+            if (isInWater()) swimTimer = Math.max(swimTimer + 1, 0);
+            else swimTimer = Math.min(swimTimer - 1, 0);
         }
         if (shedCooldown > 0) {
             shedCooldown--;
@@ -380,24 +386,18 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
                 shedCooldown = 1000 + random.nextInt(2000);
             }
         }
-        if (!level.isClientSide) {
-            if (isInWater()) {
-                swimTimer = Math.max(swimTimer + 1, 0);
-            } else {
-                swimTimer = Math.min(swimTimer - 1, 0);
-            }
-        }
     }
 
     private boolean shouldReplaceParts() {
-        if(parts == null || parts[0] == null){
+        if (parts == null || parts[0] == null)
             return true;
-        }
-        for(int i = 0; i < 7; i++){
-            if(parts[i] == null){
+
+        for (int i = 0; i < 7; i++) {
+            if (parts[i] == null) {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -411,10 +411,10 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
         }
 
         partialTicks = 1.0F - partialTicks;
-        int i = this.ringBufferIndex - bufferOffset & 63;
-        int j = this.ringBufferIndex - bufferOffset - 1 & 63;
-        float d0 = this.ringBuffer[i];
-        float d1 = this.ringBuffer[j] - d0;
+        final int i = this.ringBufferIndex - bufferOffset & 63;
+        final int j = this.ringBufferIndex - bufferOffset - 1 & 63;
+        final float d0 = this.ringBuffer[i];
+        final float d1 = this.ringBuffer[j] - d0;
         return Mth.wrapDegrees(d0 + d1 * partialTicks);
     }
 
@@ -461,8 +461,8 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
     }
 
     private float calcPartRotation(int i) {
-        float f = 1 - (this.strangleProgress * 0.2F);
-        float strangleIntensity = (float) (Mth.clamp(strangleTimer * 3, 0, 100F) * (1.0F + 0.2F * Math.sin(0.15F * strangleTimer)));
+        final float f = 1 - (this.strangleProgress * 0.2F);
+        final float strangleIntensity = (float) (Mth.clamp(strangleTimer * 3, 0, 100F) * (1.0F + 0.2F * Math.sin(0.15F * strangleTimer)));
         return (float) (40 * -Math.sin(this.walkDist * 3 - (i))) * f + this.strangleProgress * 0.2F * i * strangleIntensity;
     }
 
@@ -473,12 +473,11 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
         } else if (this.level.isClientSide) {
             return null;
         } else {
-            Vec3 vec = new Vec3(0, 0, f).yRot(-f * ((float) Math.PI / 180F));
-            ItemEntity itementity = new ItemEntity(this.level, this.getX() + vec.x, this.getY() + (double) f1, this.getZ() + vec.z, stack);
+            final Vec3 vec = new Vec3(0, 0, f).yRot(-f * ((float) Math.PI / 180F));
+            final ItemEntity itementity = new ItemEntity(this.level, this.getX() + vec.x, this.getY() + (double) f1, this.getZ() + vec.z, stack);
             itementity.setDefaultPickUpDelay();
             if (captureDrops() != null) captureDrops().add(itementity);
-            else
-                this.level.addFreshEntity(itementity);
+            else this.level.addFreshEntity(itementity);
             return itementity;
         }
     }
@@ -490,12 +489,12 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
     }
 
     public boolean shouldLeaveWater() {
-        if (!this.getPassengers().isEmpty()) {
+        if (!this.getPassengers().isEmpty())
             return false;
-        }
-        if (this.getTarget() != null && !this.getTarget().isInWater()) {
+
+        if (this.getTarget() != null && !this.getTarget().isInWater())
             return true;
-        }
+
         return swimTimer > 600 || this.isShedding();
     }
 
@@ -519,13 +518,14 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
 
     @Override
     public void killed(ServerLevel world, LivingEntity entity) {
-        CompoundTag emptyNbt = new CompoundTag();
+        final CompoundTag emptyNbt = new CompoundTag();
         entity.addAdditionalSaveData(emptyNbt);
         emptyNbt.putString("DeathLootTable", BuiltInLootTables.EMPTY.toString());
         entity.readAdditionalSaveData(emptyNbt);
-        if (this.getChild() instanceof EntityAnacondaPart) {
+
+        if (this.getChild() instanceof EntityAnacondaPart)
             ((EntityAnacondaPart) this.getChild()).setSwell(5);
-        }
+
         super.killed(world, entity);
     }
 
@@ -566,13 +566,12 @@ public class EntityAnaconda extends Animal implements ISemiAquatic {
         }
 
         public void tick() {
-            if (jumpAttemptCooldown > 0) {
+            if (jumpAttemptCooldown > 0)
                 jumpAttemptCooldown--;
-            }
-            LivingEntity target = snake.getTarget();
+
+            final LivingEntity target = snake.getTarget();
             if (target != null && target.isAlive()) {
-                double dist = snake.distanceTo(target);
-                if (dist < 1 + target.getBbWidth() && !snake.isStrangling() && jumpAttemptCooldown == 0) {
+                if (jumpAttemptCooldown == 0 && snake.distanceTo(target) < 1 + target.getBbWidth() && !snake.isStrangling()) {
                     target.hurt(DamageSource.mobAttack(snake), 4);
                     snake.setStrangling(target.getBbWidth() <= 2.3F);
                     snake.playSound(AMSoundRegistry.ANACONDA_ATTACK, snake.getSoundVolume(), snake.getVoicePitch());

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityAnteater.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityAnteater.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.alexsmobs.entity;
 
 import com.github.alexthe666.alexsmobs.config.AMConfig;
 import com.github.alexthe666.alexsmobs.entity.ai.*;
+import com.github.alexthe666.alexsmobs.entity.util.Maths;
 import com.github.alexthe666.alexsmobs.item.AMItemRegistry;
 import com.github.alexthe666.alexsmobs.misc.AMSoundRegistry;
 import com.github.alexthe666.alexsmobs.misc.AMTagRegistry;
@@ -44,6 +45,7 @@ import net.minecraft.world.level.ServerLevelAccessor;
 
 import javax.annotation.Nullable;
 import java.util.EnumSet;
+import java.util.Locale;
 import java.util.Random;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -138,9 +140,9 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
     @Override
     protected void defineSynchedData() {
         super.defineSynchedData();
-        this.entityData.define(STANDING, Boolean.valueOf(false));
-        this.entityData.define(ANT_ON_TONGUE, Boolean.valueOf(false));
-        this.entityData.define(LEANING_DOWN, Boolean.valueOf(false));
+        this.entityData.define(STANDING, Boolean.FALSE);
+        this.entityData.define(ANT_ON_TONGUE, Boolean.FALSE);
+        this.entityData.define(LEANING_DOWN, Boolean.FALSE);
         this.entityData.define(ANGER_TIME, 0);
     }
 
@@ -165,19 +167,19 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
     }
 
     public boolean isStanding() {
-        return this.entityData.get(STANDING).booleanValue();
+        return this.entityData.get(STANDING);
     }
 
     public void setStanding(boolean standing) {
-        this.entityData.set(STANDING, Boolean.valueOf(standing));
+        this.entityData.set(STANDING, standing);
     }
 
     public boolean hasAntOnTongue() {
-        return this.entityData.get(ANT_ON_TONGUE).booleanValue();
+        return this.entityData.get(ANT_ON_TONGUE);
     }
 
     public void setAntOnTongue(boolean standing) {
-        this.entityData.set(ANT_ON_TONGUE, Boolean.valueOf(standing));
+        this.entityData.set(ANT_ON_TONGUE, standing);
     }
 
     public boolean canCollideWith(Entity entity) {
@@ -191,7 +193,7 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
     }
 
     public boolean isLeaning() {
-        return this.entityData.get(LEANING_DOWN).booleanValue();
+        return this.entityData.get(LEANING_DOWN);
     }
 
     public void setLeaning(boolean leaning) {
@@ -209,12 +211,12 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
     }
 
     public InteractionResult mobInteract(Player player, InteractionHand hand) {
-        ItemStack itemstack = player.getItemInHand(hand);
-        Item item = itemstack.getItem();
-        InteractionResult type = super.mobInteract(player, hand);
-        boolean isInsect = itemstack.is(AMTagRegistry.INSECT_ITEMS);
-        if(isInsect){
-            ItemStack rippedStack = itemstack.copy();
+        final ItemStack itemstack = player.getItemInHand(hand);
+        final InteractionResult type = super.mobInteract(player, hand);
+        final boolean isInsect = itemstack.is(AMTagRegistry.INSECT_ITEMS);
+        if (isInsect) {
+            final Item item = itemstack.getItem();
+            final ItemStack rippedStack = itemstack.copy();
             rippedStack.setCount(1);
             this.stopBeingAngry();
             this.heal(4);
@@ -234,39 +236,48 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
         prevStandProgress = standProgress;
         prevTongueProgress = tongueProgress;
         prevLeaningProgress = leaningProgress;
-        boolean isTongueOut = this.getAnimation() == ANIMATION_TOUNGE_IDLE;
-        if (isStanding() && standProgress < 5F) {
-            standProgress++;
+
+        if (isStanding()) {
+            if (standProgress < 5F)
+                standProgress++;
+        } else {
+            if (standProgress > 0F)
+                standProgress--;
         }
-        if (!isStanding() && standProgress > 0F) {
-            standProgress--;
+
+        final boolean isTongueOut = this.getAnimation() == ANIMATION_TOUNGE_IDLE;
+        if (isTongueOut) {
+            if (tongueProgress < 5F)
+                tongueProgress++;
+        } else {
+            if (tongueProgress > 0F)
+                tongueProgress--;
         }
-        if (isTongueOut && tongueProgress < 5F) {
-            tongueProgress++;
+
+        if (isLeaning()) {
+            if (leaningProgress < 5F)
+                leaningProgress++;
+        } else {
+            if (leaningProgress > 0F)
+                leaningProgress--;
         }
-        if (!isTongueOut && tongueProgress > 0F) {
-            tongueProgress--;
-        }
-        if (isLeaning() && leaningProgress < 20F) {
-            leaningProgress++;
-        }
-        if (!isLeaning() && leaningProgress > 0F) {
-            leaningProgress--;
-        }
+
         if (isStanding() && ++standingTime > maxStandTime) {
             this.setStanding(false);
             standingTime = 0;
             maxStandTime = 75 + random.nextInt(50);
         }
-        if (this.isBaby() && this.isPassenger() && this.getVehicle() instanceof EntityAnteater) {
-            EntityAnteater mount = (EntityAnteater) this.getVehicle();
-            this.setYRot(mount.yBodyRot);
-            this.yHeadRot = mount.yBodyRot;
-            this.yBodyRot = mount.yBodyRot;
+
+        if (this.isPassenger() && this.getVehicle() instanceof final EntityAnteater mount) {
+            if (this.isBaby()) {
+                this.setYRot(mount.yBodyRot);
+                this.yHeadRot = mount.yBodyRot;
+                this.yBodyRot = mount.yBodyRot;
+            } else {
+                this.removeVehicle();
+            }
         }
-        if (this.isPassenger() && this.getVehicle() instanceof EntityAnteater && !this.isBaby()) {
-            this.removeVehicle();
-        }
+
         if (eatAntCooldown > 0) {
             eatAntCooldown--;
         }
@@ -312,25 +323,29 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
         } else {
             heldItemTime = 0;
         }
-        if(!level.isClientSide && getRandom().nextInt(300) == 0){
-            this.setAnimation(ANIMATION_TOUNGE_IDLE);
-        }
-        LivingEntity attackTarget = this.getTarget();
-        if (!level.isClientSide && attackTarget != null) {
-            if (distanceTo(attackTarget) < attackTarget.getBbWidth() + this.getBbWidth() + 2) {
-                if ((this.getAnimation() == ANIMATION_SLASH_L) && this.getAnimationTick() == 7) {
-                    doHurtTarget(attackTarget);
-                    float rot = getYRot() + 90;
-                    attackTarget.knockback(0.5F, Mth.sin(rot * ((float) Math.PI / 180F)), -Mth.cos(rot * ((float) Math.PI / 180F)));
-                }
-                if ((this.getAnimation() == ANIMATION_SLASH_R) && this.getAnimationTick() == 7) {
-                    doHurtTarget(attackTarget);
-                    float rot = getYRot() - 90;
-                    attackTarget.knockback(0.5F, Mth.sin(rot * ((float) Math.PI / 180F)), -Mth.cos(rot * ((float) Math.PI / 180F)));
-                }
 
+        if (!level.isClientSide) {
+            if (getRandom().nextInt(300) == 0)
+                this.setAnimation(ANIMATION_TOUNGE_IDLE);
+
+            final LivingEntity attackTarget = this.getTarget();
+            if (attackTarget != null) {
+                if (distanceTo(attackTarget) < attackTarget.getBbWidth() + this.getBbWidth() + 2) {
+                    if (this.getAnimationTick() == 7) {
+                        if (this.getAnimation() == ANIMATION_SLASH_L) {
+                            doHurtTarget(attackTarget);
+                            final float rot = getYRot() + 90;
+                            attackTarget.knockback(0.5F, Mth.sin(rot * Maths.piDividedBy180), -Mth.cos(rot * Maths.piDividedBy180));
+                        } else if (this.getAnimation() == ANIMATION_SLASH_R) {
+                            doHurtTarget(attackTarget);
+                            final float rot = getYRot() - 90;
+                            attackTarget.knockback(0.5F, Mth.sin(rot * Maths.piDividedBy180), -Mth.cos(rot * Maths.piDividedBy180));
+                        }
+                    }
+                }
             }
         }
+
         AnimationHandler.INSTANCE.updateAnimations(this);
     }
 
@@ -346,7 +361,7 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
 
     public float getTongueStickOut() {
         if (this.tongueProgress > 0F) {
-            double tongueM = Math.min(Math.sin(this.tickCount * 0.15F), 0);
+            final double tongueM = Math.min(Math.sin(this.tickCount * 0.15F), 0);
             return (float) -tongueM * (this.tongueProgress * 0.2F);
         }
         return 0.0F;
@@ -385,7 +400,7 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
 
     @Override
     public void onGetItem(ItemEntity e) {
-        ItemStack duplicate = e.getItem().copy();
+        final ItemStack duplicate = e.getItem().copy();
         duplicate.setCount(1);
         if (!this.getItemInHand(InteractionHand.MAIN_HAND).isEmpty() && !this.level.isClientSide) {
             this.spawnAtLocation(this.getItemInHand(InteractionHand.MAIN_HAND), 0.0F);
@@ -404,21 +419,23 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
     }
 
     public boolean isPeter() {
-        String s = ChatFormatting.stripFormatting(this.getName().getString());
-        return s != null && (s.toLowerCase().contains("peter") || s.toLowerCase().contains("petr") || s.toLowerCase().contains("zot"));
+        final String name = ChatFormatting.stripFormatting(this.getName().getString());
+        if (name == null)
+            return false;
+
+        final String lowercaseName = name.toLowerCase(Locale.ROOT);
+        return lowercaseName.contains("peter") || lowercaseName.contains("petr") || lowercaseName.contains("zot");
     }
 
     public SpawnGroupData finalizeSpawn(ServerLevelAccessor worldIn, DifficultyInstance difficultyIn, MobSpawnType reason, @Nullable SpawnGroupData spawnDataIn, @Nullable CompoundTag dataTag) {
-        if (spawnDataIn == null) {
+        if (spawnDataIn == null)
             spawnDataIn = new AgeableMob.AgeableMobGroupData(0.5F);
-        }
+
         return super.finalizeSpawn(worldIn, difficultyIn, reason, spawnDataIn, dataTag);
     }
 
     private class AITargetAnts extends NearestAttackableTargetGoal {
-        private static final Predicate<EntityLeafcutterAnt> QUEEN_ANT = (entity) -> {
-            return !entity.isQueen();
-        };
+        private static final Predicate<EntityLeafcutterAnt> QUEEN_ANT = (entity) -> !entity.isQueen();
 
         public AITargetAnts() {
             super(EntityAnteater.this, EntityLeafcutterAnt.class, 30, true, false, QUEEN_ANT);
@@ -446,26 +463,26 @@ public class EntityAnteater extends Animal implements NeutralMob, IAnimatedEntit
         }
 
         public void tick() {
-            LivingEntity enemy = EntityAnteater.this.getTarget();
-            double d0 = this.getAttackReachSqr(enemy);
-            double distToEnemySqr = EntityAnteater.this.distanceTo(enemy);
+            final LivingEntity enemy = EntityAnteater.this.getTarget();
+            final double attackReachSqr = this.getAttackReachSqr(enemy);
+            final double distToEnemySqr = EntityAnteater.this.distanceTo(enemy);
             EntityAnteater.this.lookAt(enemy, 100, 5);
             if (enemy instanceof EntityLeafcutterAnt) {
-                if (distToEnemySqr <= d0 + 1.5F) {
+                if (distToEnemySqr <= attackReachSqr + 1.5F) {
                     EntityAnteater.this.setAnimation(ANIMATION_TOUNGE_IDLE);
                 } else {
                     EntityAnteater.this.lookAt(enemy, 5, 5);
                 }
                 EntityAnteater.this.getNavigation().moveTo(enemy, 1.0D);
             } else {
-                if (distToEnemySqr <= d0) {
+                if (distToEnemySqr <= attackReachSqr) {
                     EntityAnteater.this.getNavigation().moveTo(enemy, 1.0D);
                     EntityAnteater.this.setAnimation(EntityAnteater.this.getRandom().nextBoolean() ? ANIMATION_SLASH_L : ANIMATION_SLASH_R);
                 }
-                double d1 = enemy.getX() - EntityAnteater.this.getX();
-                double d2 = enemy.getZ() - EntityAnteater.this.getZ();
-                double d3 = (double)Mth.sqrt((float) (d1 * d1 + d2 * d2));
-                float f = (float)(Mth.atan2(d2, d1) * (double)(180F / (float)Math.PI)) - 90.0F;
+                final double x = enemy.getX() - EntityAnteater.this.getX();
+                final double z = enemy.getZ() - EntityAnteater.this.getZ();
+//                double d3 = (double)Mth.sqrt((float) (x * x + z * z));
+                final float f = (float) (Mth.atan2(z, x) * Maths.oneEightyDividedByFloatPi) - 90.0F;
                 EntityAnteater.this.setYRot(f);
                 EntityAnteater.this.yBodyRot = f;
                 EntityAnteater.this.setStanding(true);

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/AnimalAIFindWater.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/AnimalAIFindWater.java
@@ -14,7 +14,7 @@ import net.minecraft.world.entity.ai.goal.Goal.Flag;
 public class AnimalAIFindWater extends Goal {
     private final PathfinderMob creature;
     private BlockPos targetPos;
-    private int executionChance = 30;
+    private final int executionChance = 30;
 
     public AnimalAIFindWater(PathfinderMob creature) {
         this.creature = creature;
@@ -22,8 +22,8 @@ public class AnimalAIFindWater extends Goal {
     }
 
     public boolean canUse() {
-        if (this.creature.isOnGround() && !this.creature.level.getFluidState(this.creature.blockPosition()).is(FluidTags.WATER)){
-            if(this.creature instanceof ISemiAquatic && ((ISemiAquatic) this.creature).shouldEnterWater() && (this.creature.getTarget() != null || this.creature.getRandom().nextInt(executionChance) == 0)){
+        if (this.creature.isOnGround() && !this.creature.level.getFluidState(this.creature.blockPosition()).is(FluidTags.WATER)) {
+            if (this.creature instanceof ISemiAquatic && ((ISemiAquatic) this.creature).shouldEnterWater() && (this.creature.getTarget() != null || this.creature.getRandom().nextInt(executionChance) == 0)) {
                 targetPos = generateTarget();
                 return targetPos != null;
             }
@@ -32,19 +32,19 @@ public class AnimalAIFindWater extends Goal {
     }
 
     public void start() {
-        if(targetPos != null){
+        if (targetPos != null) {
             this.creature.getNavigation().moveTo(targetPos.getX(), targetPos.getY(), targetPos.getZ(), 1D);
         }
     }
 
     public void tick() {
-        if(targetPos != null){
+        if (targetPos != null) {
             this.creature.getNavigation().moveTo(targetPos.getX(), targetPos.getY(), targetPos.getZ(), 1D);
         }
     }
 
     public boolean canContinueToUse() {
-        if(this.creature instanceof ISemiAquatic && !((ISemiAquatic) this.creature).shouldEnterWater()){
+        if (this.creature instanceof ISemiAquatic && !((ISemiAquatic) this.creature).shouldEnterWater()) {
             this.creature.getNavigation().stop();
             return false;
         }
@@ -53,15 +53,16 @@ public class AnimalAIFindWater extends Goal {
 
     public BlockPos generateTarget() {
         BlockPos blockpos = null;
-        Random random = new Random();
-        int range = this.creature instanceof ISemiAquatic ? ((ISemiAquatic) this.creature).getWaterSearchRange() : 14;
-        for(int i = 0; i < 15; i++){
-            BlockPos blockpos1 = this.creature.blockPosition().offset(random.nextInt(range) - range/2, 3, random.nextInt(range) - range/2);
-            while(this.creature.level.isEmptyBlock(blockpos1) && blockpos1.getY() > 1){
-                blockpos1 = blockpos1.below();
+        final Random random = new Random();
+        final int range = this.creature instanceof ISemiAquatic ? ((ISemiAquatic) this.creature).getWaterSearchRange() : 14;
+        for(int i = 0; i < 15; i++) {
+            BlockPos blockPos = this.creature.blockPosition().offset(random.nextInt(range) - range/2, 3, random.nextInt(range) - range/2);
+            while (this.creature.level.isEmptyBlock(blockPos) && blockPos.getY() > 1) {
+                blockPos = blockPos.below();
             }
-            if(this.creature.level.getFluidState(blockpos1).is(FluidTags.WATER)){
-                blockpos = blockpos1;
+
+            if (this.creature.level.getFluidState(blockPos).is(FluidTags.WATER)) {
+                blockpos = blockPos;
             }
         }
         return blockpos;

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/AnimalAILeaveWater.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/AnimalAILeaveWater.java
@@ -1,6 +1,7 @@
 package com.github.alexthe666.alexsmobs.entity.ai;
 
 import com.github.alexthe666.alexsmobs.entity.ISemiAquatic;
+import com.github.alexthe666.alexsmobs.entity.util.Maths;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.util.LandRandomPos;
 import net.minecraft.world.entity.ai.util.RandomPos;
@@ -17,7 +18,7 @@ import net.minecraft.world.entity.ai.goal.Goal.Flag;
 public class AnimalAILeaveWater extends Goal {
     private final PathfinderMob creature;
     private BlockPos targetPos;
-    private int executionChance = 30;
+    private final int executionChance = 30;
 
     public AnimalAILeaveWater(PathfinderMob creature) {
         this.creature = creature;
@@ -25,8 +26,8 @@ public class AnimalAILeaveWater extends Goal {
     }
 
     public boolean canUse() {
-        if (this.creature.level.getFluidState(this.creature.blockPosition()).is(FluidTags.WATER) && (this.creature.getTarget() != null || this.creature.getRandom().nextInt(executionChance) == 0)){
-            if(this.creature instanceof ISemiAquatic && ((ISemiAquatic) this.creature).shouldLeaveWater()){
+        if (this.creature.level.getFluidState(this.creature.blockPosition()).is(FluidTags.WATER) && (this.creature.getTarget() != null || this.creature.getRandom().nextInt(executionChance) == 0)) {
+            if (this.creature instanceof ISemiAquatic && ((ISemiAquatic) this.creature).shouldLeaveWater()) {
                 targetPos = generateTarget();
                 return targetPos != null;
             }
@@ -35,24 +36,24 @@ public class AnimalAILeaveWater extends Goal {
     }
 
     public void start() {
-        if(targetPos != null){
+        if (targetPos != null) {
             this.creature.getNavigation().moveTo(targetPos.getX(), targetPos.getY(), targetPos.getZ(), 1D);
         }
     }
 
     public void tick() {
-        if(targetPos != null){
+        if (targetPos != null) {
             this.creature.getNavigation().moveTo(targetPos.getX(), targetPos.getY(), targetPos.getZ(), 1D);
         }
-        if(this.creature.horizontalCollision && this.creature.isInWater()){
-            float f1 = creature.getYRot() * ((float)Math.PI / 180F);
-            creature.setDeltaMovement(creature.getDeltaMovement().add((double)(-Mth.sin(f1) * 0.2F), 0.1D, (double)(Mth.cos(f1) * 0.2F)));
+        if (this.creature.horizontalCollision && this.creature.isInWater()) {
+            final float f1 = creature.getYRot() * Maths.piDividedBy180;
+            creature.setDeltaMovement(creature.getDeltaMovement().add(-Mth.sin(f1) * 0.2F, 0.1D, Mth.cos(f1) * 0.2F));
 
         }
     }
 
     public boolean canContinueToUse() {
-        if(this.creature instanceof ISemiAquatic && !((ISemiAquatic) this.creature).shouldLeaveWater()){
+        if (this.creature instanceof ISemiAquatic && !((ISemiAquatic) this.creature).shouldLeaveWater()) {
             this.creature.getNavigation().stop();
             return false;
         }
@@ -62,7 +63,7 @@ public class AnimalAILeaveWater extends Goal {
     public BlockPos generateTarget() {
         Vec3 vector3d = LandRandomPos.getPos(this.creature, 23, 7);
         int tries = 0;
-        while(vector3d != null && tries < 8){
+        while(vector3d != null && tries < 8) {
             boolean waterDetected = false;
             for(BlockPos blockpos1 : BlockPos.betweenClosed(Mth.floor(vector3d.x - 2.0D), Mth.floor(vector3d.y - 1.0D), Mth.floor(vector3d.z - 2.0D), Mth.floor(vector3d.x + 2.0D), Mth.floor(vector3d.y), Mth.floor(vector3d.z + 2.0D))) {
                 if (this.creature.level.getFluidState(blockpos1).is(FluidTags.WATER)) {
@@ -70,9 +71,9 @@ public class AnimalAILeaveWater extends Goal {
                     break;
                 }
             }
-            if(waterDetected){
+            if (waterDetected) {
                 vector3d = LandRandomPos.getPos(this.creature, 23, 7);
-            }else{
+            } else {
                 return new BlockPos(vector3d);
             }
             tries++;

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/BottomFeederAIWander.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/BottomFeederAIWander.java
@@ -30,7 +30,7 @@ public class BottomFeederAIWander extends RandomStrollGoal {
     }
 
     public boolean canUse(){
-        if(mob instanceof ISemiAquatic && ((ISemiAquatic) mob).shouldStopMoving()){
+        if (mob instanceof ISemiAquatic && ((ISemiAquatic) mob).shouldStopMoving()) {
             return false;
         }
         interval = mob.isInWater() ? waterChance : landChance;
@@ -38,9 +38,9 @@ public class BottomFeederAIWander extends RandomStrollGoal {
     }
 
     public boolean canContinueToUse() {
-        if(mob instanceof ISemiAquatic && ((ISemiAquatic) mob).shouldStopMoving()){
+        if (mob instanceof ISemiAquatic && ((ISemiAquatic) mob).shouldStopMoving())
             return false;
-        }
+
         return super.canContinueToUse();
     }
 
@@ -50,12 +50,12 @@ public class BottomFeederAIWander extends RandomStrollGoal {
             BlockPos blockpos = null;
             Random random = new Random();
             for (int i = 0; i < 15; i++) {
-                BlockPos blockpos1 = this.mob.blockPosition().offset(random.nextInt(range) - range / 2, 3, random.nextInt(range) - range / 2);
-                while ((this.mob.level.isEmptyBlock(blockpos1) || this.mob.level.getFluidState(blockpos1).is(FluidTags.WATER)) && blockpos1.getY() > 1) {
-                    blockpos1 = blockpos1.below();
+                BlockPos blockPos = this.mob.blockPosition().offset(random.nextInt(range) - range / 2, 3, random.nextInt(range) - range / 2);
+                while ((this.mob.level.isEmptyBlock(blockPos) || this.mob.level.getFluidState(blockPos).is(FluidTags.WATER)) && blockPos.getY() > 1) {
+                    blockPos = blockPos.below();
                 }
-                if (isBottomOfSeafloor(this.mob.level, blockpos1.above())) {
-                    blockpos = blockpos1;
+                if (isBottomOfSeafloor(this.mob.level, blockPos.above())) {
+                    blockpos = blockPos;
                 }
             }
 

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SemiAquaticAIRandomSwimming.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SemiAquaticAIRandomSwimming.java
@@ -20,7 +20,7 @@ public class SemiAquaticAIRandomSwimming extends RandomStrollGoal {
     }
 
     public boolean canUse() {
-        if (this.mob.isVehicle() || ((ISemiAquatic)mob).shouldStopMoving() || mob.getTarget() != null || !this.mob.isInWater() && !this.mob.isInLava() && this.mob instanceof ISemiAquatic && !((ISemiAquatic) this.mob).shouldEnterWater()) {
+        if (this.mob.isVehicle() || ((ISemiAquatic)this.mob).shouldStopMoving() || this.mob.getTarget() != null || !this.mob.isInWater() && !this.mob.isInLava() && this.mob instanceof ISemiAquatic && !((ISemiAquatic) this.mob).shouldEnterWater()) {
             return false;
         } else {
             if (!this.forceTrigger) {
@@ -28,7 +28,7 @@ public class SemiAquaticAIRandomSwimming extends RandomStrollGoal {
                     return false;
                 }
             }
-            Vec3 vector3d = this.getPosition();
+            final Vec3 vector3d = this.getPosition();
             if (vector3d == null) {
                 return false;
             } else {
@@ -61,7 +61,7 @@ public class SemiAquaticAIRandomSwimming extends RandomStrollGoal {
     }
 
     private boolean canJumpTo(BlockPos pos, int dx, int dz, int scale) {
-        BlockPos blockpos = pos.offset(dx * scale, 0, dz * scale);
+        final BlockPos blockpos = pos.offset(dx * scale, 0, dz * scale);
         return this.mob.level.getFluidState(blockpos).is(FluidTags.LAVA) || this.mob.level.getFluidState(blockpos).is(FluidTags.WATER) && !this.mob.level.getBlockState(blockpos).getMaterial().blocksMotion();
     }
 
@@ -71,10 +71,10 @@ public class SemiAquaticAIRandomSwimming extends RandomStrollGoal {
 
     protected Vec3 findSurfaceTarget(PathfinderMob creature, int i, int i1) {
         BlockPos upPos = creature.blockPosition();
-        while(creature.level.getFluidState(upPos).is(FluidTags.WATER) || creature.level.getFluidState(upPos).is(FluidTags.LAVA)){
+        while (creature.level.getFluidState(upPos).is(FluidTags.WATER) || creature.level.getFluidState(upPos).is(FluidTags.LAVA)) {
             upPos = upPos.above();
         }
-        if(isAirAbove(upPos.below(), 0, 0, 0) && canJumpTo(upPos.below(), 0, 0, 0)){
+        if (isAirAbove(upPos.below(), 0, 0, 0) && canJumpTo(upPos.below(), 0, 0, 0)) {
             return new Vec3(upPos.getX() + 0.5F, upPos.getY() - 1F, upPos.getZ() + 0.5F);
         }
         return null;

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/util/AnacondaPartIndex.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/util/AnacondaPartIndex.java
@@ -1,50 +1,31 @@
 package com.github.alexthe666.alexsmobs.entity.util;
 
-import net.minecraft.util.Mth;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.phys.Vec3;
-
 public enum AnacondaPartIndex {
     HEAD(0F), NECK(0.5F), BODY(0.5F), TAIL(0.4F);
 
-    private float backOffset;
+    private final float backOffset;
 
     AnacondaPartIndex(float partOffset){
         this.backOffset = partOffset;
     }
 
-    public static AnacondaPartIndex fromOrdinal(int i){
-        switch (i){
-            case 0:
-                return HEAD;
-            case 1:
-                return NECK;
-            case 2:
-                return BODY;
-            case 3:
-                return TAIL;
-        }
+    public static AnacondaPartIndex fromOrdinal(int i) {
+        return switch (i) {
+            case 0 -> HEAD;
+            case 1 -> NECK;
+            case 3 -> TAIL;
+            default -> BODY; // case 2 and others
+        };
 
-        return BODY;
     }
 
-    public static AnacondaPartIndex sizeAt(int bodyindex){
-        switch (bodyindex){
-            case 0:
-                return HEAD;
-            case 1:
-                return NECK;
-            case 2:
-            case 3:
-            case 4:
-                return BODY;
-            case 5:
-            case 6:
-                return NECK;
-            case 7:
-                return TAIL;
-        }
-        return BODY;
+    public static AnacondaPartIndex sizeAt(int bodyindex) {
+        return switch (bodyindex) {
+            case 0 -> HEAD;
+            case 1, 5, 6 -> NECK;
+            case 7 -> TAIL;
+            default -> BODY; // cases 2, 3, 4 and others
+        };
     }
 
     public float getBackOffset() {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/util/Maths.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/util/Maths.java
@@ -1,0 +1,6 @@
+package com.github.alexthe666.alexsmobs.entity.util;
+
+public class Maths {
+    public static double oneEightyDividedByFloatPi = 180.0F / (float) Math.PI;
+    public static float piDividedBy180 = (float) Math.PI / 180.0F;
+}


### PR DESCRIPTION
This PR cleans up and optimises entities starting with A (and things they reference) by:

- Reducing unnecessary checks and calculations
- Reordering if statements to fail early on the quicker checks first
- Deferring assignments/calculations/checks closer to where they're used
- Marking variables as final where appropriate
- Commenting out some dead/unused code
- Slightly simplifying some calculations
- Avoiding unnecessary boxing and unboxing
- Converting Strings to lowercase once and do `contains()` checks on that, rather than repeatedly converting to lowercase on every `contains()` check. (see `EntityAnteater#isPeter()`)
- Using modern Java features to make some code more concise (see `AnacondaPartIndex` for an example of this)
- Fixing some minor code style inconsistencies

Due to the large amount of mobs your mod adds and wanting to avoid ending up a single overwhelmingly large PR, this PR only affects AlligatorSnappingTurtles, Anacondas, Anteaters and stuff they reference.

Future PRs are likely to be made for other entities depending on feedback or merging of this one.

*Sponsored by [The Modding Inquisition](https://github.com/TheModdingInquisition)*