### PR TITLE
FroststalkerAIMelee Fix for #1140 and probably #1146

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/FroststalkerAIMelee.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/FroststalkerAIMelee.java
@@ -60,6 +60,7 @@ public class FroststalkerAIMelee extends Goal {
     public void tick() {
         froststalker.setBipedal(true);
         froststalker.standFor(20);
+        target = froststalker.getTarget();
         boolean flag = false;
         if ((hasJumped || froststalker.isTackling()) && froststalker.isOnGround()) {
             hasJumped = false;
@@ -113,7 +114,7 @@ public class FroststalkerAIMelee extends Goal {
                 }
             }
         }
-        if (!froststalker.isOnGround()) {
+        if (target != null && !froststalker.isOnGround()) {
             froststalker.lookAt(target, 180F, 10F);
             froststalker.yBodyRot = froststalker.getYRot();
         }


### PR DESCRIPTION
Fixes `FroststalkerAIMelee` not updating the target and getting stuck forever on an invalid target. (#1140)
Also adds a null check to the not grounded state as a precaution for #1146