### PR TITLE
Added custom Catalogue item icon to prevent rendering issue

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -26,3 +26,5 @@ description='''New, original, engaging, and aesthetic mobs for Minecraft.'''
     versionRange="[36.0.42,)"
     ordering="NONE"
     side="BOTH"
+[modproperties.alexsmobs]
+    catalogueItemIcon="alexsmobs:cosmic_cod"


### PR DESCRIPTION
I've added a simple entry into the mods.toml to provide a custom item icon to the mod Catalogue. An [issue](https://github.com/MrCrayfish/Configured/issues/55#issuecomment-1181738270) has been reported, that rendering the Tab Item from your mod when level is null causes all entities to become invisible once you load a level. I'm not entirely sure internally why this happens but providing a custom icon will prevent the issue. Catalogue for reference is a mod that transforms Forge's mod list into a more friendly and modern design, and attempts to use items as an icon for a mod entry. The item used is the first one found from a mod and coincidently it's the Tab Item from your mod.

The two lines can easily be added to 1.19 to prevent issues there too.

If you feel the need, you can replace this fix with a custom png icon instead if you want full control of branding. The file should be placed into the same directory as your pack.mcmeta and this image must be 1:1 ratio and preferrably small for memory sake.
```toml
[modproperties.alexmobs]
    catalogueImageIcon="alexmobs_icon.png"
```

Example of Citadel
![image](https://user-images.githubusercontent.com/4958241/178504066-e1d1ea37-b26d-49af-a12c-e9f62517e400.png)
