### PR TITLE
allow murmur to render its head as a fake entity and fix creative tab placement

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderMurmurBody.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/client/render/RenderMurmurBody.java
@@ -29,7 +29,7 @@ public class RenderMurmurBody extends MobRenderer<EntityMurmur, ModelMurmurBody>
 
     public void render(EntityMurmur body, float entityYaw, float partialTicks, PoseStack matrixStackIn, MultiBufferSource bufferIn, int packedLightIn) {
         super.render(body, entityYaw, partialTicks, matrixStackIn, bufferIn, packedLightIn);
-        if(renderWithHead){
+        if (renderWithHead || body.shouldRenderFakeHead()) {
             float f = Mth.rotLerp(partialTicks, body.yBodyRotO, body.yBodyRot);
             float f7 = this.getBob(body, partialTicks);
             ResourceLocation loc = this.getTextureLocation(body);

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityMurmur.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityMurmur.java
@@ -35,6 +35,8 @@ public class EntityMurmur extends Monster implements ISemiAquatic {
 
     private static final EntityDataAccessor<Optional<UUID>> HEAD_UUID = SynchedEntityData.defineId(EntityMurmur.class, EntityDataSerializers.OPTIONAL_UUID);
     private static final EntityDataAccessor<Integer> HEAD_ID = SynchedEntityData.defineId(EntityMurmur.class, EntityDataSerializers.INT);
+    private boolean renderFakeHead = true;
+
 
     protected EntityMurmur(EntityType<? extends Monster> type, Level level) {
         super(type, level);
@@ -115,8 +117,13 @@ public class EntityMurmur extends Monster implements ISemiAquatic {
         }
     }
 
+    public boolean shouldRenderFakeHead() {
+        return this.renderFakeHead;
+    }
+
     public void tick() {
         super.tick();
+        if (this.renderFakeHead) this.renderFakeHead = false;
         this.yBodyRot = this.getYRot();
         this.yHeadRot = Mth.clamp(this.yHeadRot, this.yBodyRot - 70, this.yBodyRot + 70);
         if (!this.level().isClientSide) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/misc/AMCreativeTabRegistry.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/misc/AMCreativeTabRegistry.java
@@ -6,6 +6,7 @@ import com.github.alexthe666.alexsmobs.item.CustomTabBehavior;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.registries.DeferredRegister;
@@ -18,6 +19,7 @@ public class AMCreativeTabRegistry {
 
     public static final RegistryObject<CreativeModeTab> TAB = DEF_REG.register(AlexsMobs.MODID, () -> CreativeModeTab.builder()
             .title(Component.translatable("itemGroup." + AlexsMobs.MODID))
+            .withTabsBefore(CreativeModeTabs.SPAWN_EGGS)
             .icon(() -> new ItemStack(AMItemRegistry.TAB_ICON.get()))
             .displayItems((enabledFeatures, output) -> {
                 for(RegistryObject<Item> item : AMItemRegistry.DEF_REG.getEntries()){


### PR DESCRIPTION
Hey,
I work on a small mod known as [OpenBlocks Trophies](https://www.curseforge.com/minecraft/mc-mods/openblocks-trophies). I have full support for this mod built-in, but one trophy that gives me problems is the Murmur trophy. Since I want the murmur to render with a head, I found that I have to call `RenderMurmurBody.renderWithHead = true` in my rendering code. I personally hate this, and didn't want to have to call anything but rather have the Murmur render with a head when rendering as a "fake entity". 
I figured out a solution to this a while ago for Twilight Forest's Hydra, and figured I would apply something similar here. This fix allows all mods that render the murmur as a fake entity (things like my mod and JER for example) to render the murmur in its entirety instead of just as a body. 

This PR also fixes the placement of the creative tab. You have to call `.withTabsBefore(CreativeModeTabs.SPAWN_EGGS)` to properly place your tabs after vanilla's. It seems like none of your other mods do this either, I would highly recommend adding it :)

Thanks for hearing me out! <3