### PR TITLE
Fixes https://github.com/AlexModGuy/AlexsMobs/issues/1717

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCachalotPart.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityCachalotPart.java
@@ -79,7 +79,7 @@ public class EntityCachalotPart extends PartEntity<EntityCachalotWhale> {
     }
 
     public EntityDimensions getDimensions(Pose poseIn) {
-        return this.size.scale(scale);
+        return this.size == null ? EntityDimensions.scalable(0, 0) : this.size.scale(scale);
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGiantSquidPart.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityGiantSquidPart.java
@@ -84,7 +84,7 @@ public class EntityGiantSquidPart extends PartEntity<EntityGiantSquid> implement
     }
 
     public EntityDimensions getDimensions(Pose poseIn) {
-        return this.size.scale(scale);
+        return this.size == null ? EntityDimensions.scalable(0, 0) : this.size.scale(scale);
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityLaviathanPart.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityLaviathanPart.java
@@ -71,7 +71,7 @@ public class EntityLaviathanPart extends PartEntity<EntityLaviathan> {
     }
 
     public EntityDimensions getDimensions(Pose poseIn) {
-        return this.size.scale(scale);
+        return this.size == null ? EntityDimensions.scalable(0, 0) : this.size.scale(scale);
     }
 
     @Override


### PR DESCRIPTION
Simply checks for size to be null before resolving dimensions of parts of multipart mobs (due to the initialisation order the mob size is set *after* this is checked for the first time, so we simply return (0, 0) and resize afterwards)