### PR TITLE
Fix Kimono and Bug Pheromone not working

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
@@ -598,12 +598,14 @@ public class ServerEvents {
         if (event.getNewTarget() != null && event.getEntity() instanceof Mob mob) {
             if (mob.getMobType() == MobType.ARTHROPOD) {
                 if (event.getNewTarget().hasEffect(AMEffectRegistry.BUG_PHEROMONES.get()) && event.getEntity().getLastHurtByMob() != event.getNewTarget()) {
-                    mob.setTarget(null);
+                    event.setCanceled(true);
+                    return;
                 }
             }
             if (mob.getMobType() == MobType.UNDEAD && !mob.getType().is(AMTagRegistry.IGNORES_KIMONO)) {
                 if (event.getNewTarget().getItemBySlot(EquipmentSlot.CHEST).is(AMItemRegistry.UNSETTLING_KIMONO.get()) && event.getEntity().getLastHurtByMob() != event.getNewTarget()) {
-                    mob.setTarget(null);
+                    event.setCanceled(true);
+                    return;
                 }
             }
         }


### PR DESCRIPTION
LivingChangeTargetEvent is posted before setting target while previous LivingSetAttackTargetEvent is posted after. To change the new target in LivingChangeTargetEvent you have to use event.setNewTarget(). By simply calling mob.setTarget(null) without changing the new target in event, it doesn't work because the original new target in event will be still set after posting the event.