### PR TITLE
Fixes #1536 for 1.19.2

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityVoidPortal.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityVoidPortal.java
@@ -26,6 +26,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.entity.PartEntity;
 import net.minecraftforge.network.NetworkHooks;
 import net.minecraftforge.network.PlayMessages;
 import org.antlr.v4.runtime.misc.Triple;
@@ -132,7 +133,7 @@ public class EntityVoidPortal extends Entity {
             if (this.getDestination() != null && this.getLifespan() > 20 && tickCount > 20) {
                 BlockPos offsetPos = this.getDestination().relative(this.getAttachmentFacing().getOpposite(), 2);
                 for (Entity e : entities) {
-                    if(e.isOnPortalCooldown() || e.isShiftKeyDown() || e instanceof EntityVoidPortal || e.getParts() != null || e.getType().is(AMTagRegistry.VOID_PORTAL_IGNORES)){
+                    if(e.isOnPortalCooldown() || e.isShiftKeyDown() || e instanceof EntityVoidPortal || e.getParts() != null || e instanceof PartEntity<?> || e.getType().is(AMTagRegistry.VOID_PORTAL_IGNORES)){
                         continue;
                     }
                     if (e instanceof EntityVoidWormPart) {


### PR DESCRIPTION
Added a check for `PartEntity` during the filtering of the gathered `Entity` list during `EntityVoidPortal#tick`. You have already established that multipart entities should not be teleported via these portals (`e.getParts() != null`), so I am simply reinforcing this check by filtering out their `PartEntity`s.

The original error was a result of `EntityVoidPortal#teleportEntityFromDimension` creating a new `Entity` from the previous one's `EntityType`, but the `EntityType` of a `PartEntity` is the same as its parent mob (For example, the `EntityType` of an `EntityLaviathinPart` is the same as `EntityLaviathin`). So these `PartEntity`s are getting copied over to the other dimension as brand new instances of their parent mob.