### PR TITLE
Fix: Armors with custom attributes remove armor provided by different armor slots

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/item/ItemModArmor.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/item/ItemModArmor.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.UUID;
 
 public class ItemModArmor extends ArmorItem {
-    private static final UUID[] ARMOR_MODIFIERS = new UUID[]{UUID.fromString("845DB27C-C624-495F-8C9F-6020A9A58B6B"), UUID.fromString("D8499B04-0E66-4726-AB29-64469D734E0D"), UUID.fromString("9F3D476D-C118-4544-8365-64846904B48E"), UUID.fromString("2AD3F246-FEE1-4E67-B886-69FD380BB150")};
+    private static final UUID[] ARMOR_MODIFIERS = new UUID[]{UUID.fromString("2AD3F246-FEE1-4E67-B886-69FD380BB150"), UUID.fromString("9F3D476D-C118-4544-8365-64846904B48E"), UUID.fromString("D8499B04-0E66-4726-AB29-64469D734E0D"), UUID.fromString("845DB27C-C624-495F-8C9F-6020A9A58B6B")};
     private Multimap<Attribute, AttributeModifier> attributeMapCroc;
     private Multimap<Attribute, AttributeModifier> attributeMapMoose;
     private Multimap<Attribute, AttributeModifier> attributeMapFlyingFish;


### PR DESCRIPTION
Fixes #1775 
Fixes #1659

### Problem
The Unsettling Kimono and Crocodile Chestplate would remove armor provided by leggings
The Flying Fish boots would remove armor provided by helmets
The Antler Headdress would remove armor provided by boots

### Cause
The Armor Attribute UUIDs which these armors base their attributes on were provided in the order that they appear in vanilla's ArmorItem class: Boots->Leggings->Chestplate->Helmet. The ArmorItem.Type enum however is defined in the opposite order. Indexing directly by the enum will thus get you the wrong UUID

### Implemented Solution
Reversed the order of the UUID's in the ItemModArmor class.