### PR TITLE
Fix Leafcutter Ants forgetting their home pos after harvesting a leaf

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityLeafcutterAnt.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityLeafcutterAnt.java
@@ -686,7 +686,6 @@ public class EntityLeafcutterAnt extends Animal implements NeutralMob, IAnimated
         }
 
         public void start() {
-            this.hivePos = null;
             this.searchCooldown = 20;
             this.approachTime = 0;
             moveToCooldown = 10 + random.nextInt(10);


### PR DESCRIPTION
Leafcutter Ants no longer forget their home pos after harvesting a leaf. Fixes #1961