### PR TITLE
Account for attribute modifiers when splitting void worm

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityVoidWorm.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityVoidWorm.java
@@ -378,10 +378,14 @@ public class EntityVoidWorm extends Monster {
         }
     }
 
-    public void setMaxHealth(double maxHealth, boolean heal){
+    public double getBaseMaxHealth() {
+        return this.getAttributeBaseValue(Attributes.MAX_HEALTH);
+    }
+
+    public void setBaseMaxHealth(double maxHealth, boolean heal){
         this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(maxHealth);
         if(heal){
-            this.heal((float)maxHealth);
+            this.heal(this.getMaxHealth());
         }
     }
 
@@ -471,7 +475,7 @@ public class EntityVoidWorm extends Monster {
             reason, @Nullable SpawnGroupData spawnDataIn, @Nullable CompoundTag dataTag) {
         this.setSegmentCount(25 + random.nextInt(15));
         this.setXRot(0.0F);
-        this.setMaxHealth(AMConfig.voidWormMaxHealth, true);
+        this.setBaseMaxHealth(AMConfig.voidWormMaxHealth, true);
         return super.finalizeSpawn(worldIn, difficultyIn, reason, spawnDataIn, dataTag);
     }
 

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityVoidWormPart.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityVoidWormPart.java
@@ -314,7 +314,7 @@ public class EntityVoidWormPart extends LivingEntity implements IHurtableMultipa
                     level().addFreshEntity(worm2);
                 }
                 worm2.setSplitter(true);
-                worm2.setMaxHealth(worm.getMaxHealth() / 2F, true);
+                worm2.setBaseMaxHealth(worm.getBaseMaxHealth() / 2F, true);
                 worm2.setSplitFromUuid(worm.getUUID());
                 worm2.setWormSpeed((float) Mth.clamp(worm.getWormSpeed() * 0.8, 0.4F, 1F));
                 worm2.resetWormScales();

--- a/src/main/java/com/github/alexthe666/alexsmobs/item/ItemMysteriousWorm.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/item/ItemMysteriousWorm.java
@@ -35,7 +35,7 @@ public class ItemMysteriousWorm extends Item {
                 worm.setSegmentCount(25 + new Random().nextInt(15));
                 worm.setXRot(-90.0F);
                 worm.updatePostSummon = true;
-                worm.setMaxHealth(AMConfig.voidWormMaxHealth, true);
+                worm.setBaseMaxHealth(AMConfig.voidWormMaxHealth, true);
 
                 if(!entity.level().isClientSide){
                     Entity thrower = entity.getOwner();


### PR DESCRIPTION
If the void worm has attribute modifiers for its max health, we use the
modified value to set the base health value, and so if the attribute
gets reapplied by a mob leveling mod this can result in the modifier
compounding (e.g. for the real example encountered that motivates this
fix, if the initial worm has a 4x modifier on its max health then the
new split worm will inherit half the quadrupled health as its base
health, which when the 4x modifier is applied on top of that gives
double the health of the first worm, giving exponential growth for the
health of the worms).

Switch to using the base value instead as the input, clarify that we're
setting the base value and adjust the healing implementation to ensure
we heal by the full amount, not the base amount.
