### PR TITLE
My seagull fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySeagull.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySeagull.java
@@ -79,6 +79,7 @@ public class EntitySeagull extends Animal implements ITargetsDroppedItems {
     public float prevAttackProgress;
     public float sitProgress;
     public float prevSitProgress;
+    public int postSeedCooldown = 0;
     public int stealCooldown = random.nextInt(2500);
     private boolean isLandNavigator;
     private int timeFlying;
@@ -91,6 +92,7 @@ public class EntitySeagull extends Animal implements ITargetsDroppedItems {
     private int heldItemTime = 0;
     public int treasureSitTime;
     public UUID feederUUID = null;
+    public boolean hasEatenSeed = false; // Add this line
 
     protected EntitySeagull(EntityType type, Level worldIn) {
         super(type, worldIn);
@@ -281,6 +283,10 @@ public class EntitySeagull extends Animal implements ITargetsDroppedItems {
         } else {
             if (flyProgress > 0F)
                 flyProgress--;
+        }
+
+        if (postSeedCooldown > 0) {
+            postSeedCooldown--;
         }
 
         if (sitting) {

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySeagull.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySeagull.java
@@ -1,14 +1,17 @@
 package com.github.alexthe666.alexsmobs.entity;
 
+import com.github.alexthe666.alexsmobs.entity.ai.SeagullAITargetSeeds;
 import com.github.alexthe666.alexsmobs.config.AMConfig;
 import com.github.alexthe666.alexsmobs.entity.ai.CreatureAITargetItems;
 import com.github.alexthe666.alexsmobs.entity.ai.DirectPathNavigator;
 import com.github.alexthe666.alexsmobs.entity.ai.SeagullAIRevealTreasure;
 import com.github.alexthe666.alexsmobs.entity.ai.SeagullAIStealFromPlayers;
+import com.github.alexthe666.alexsmobs.entity.ai.SeagullAITargetSeeds;
 import com.github.alexthe666.alexsmobs.entity.util.Maths;
 import com.github.alexthe666.alexsmobs.misc.AMBlockPos;
 import com.github.alexthe666.alexsmobs.misc.AMSoundRegistry;
 import com.github.alexthe666.alexsmobs.misc.AMTagRegistry;
+import com.github.alexthe666.citadel.repack.jcodec.common.tools.MainUtils.Flag;
 import com.google.common.base.Predicate;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -148,6 +151,7 @@ public class EntitySeagull extends Animal implements ITargetsDroppedItems {
     protected void registerGoals() {
         super.registerGoals();
         this.goalSelector.addGoal(0, new FloatGoal(this));
+        this.goalSelector.addGoal(2, new SeagullAITargetSeeds(this));
         this.targetSelector.addGoal(1, new SeagullAIRevealTreasure(this));
         this.targetSelector.addGoal(2, new SeagullAIStealFromPlayers(this));
         this.goalSelector.addGoal(3, new BreedGoal(this, 1.0D));

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySnowLeopard.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySnowLeopard.java
@@ -161,6 +161,7 @@ public class EntitySnowLeopard extends Animal implements IAnimatedEntity, ITarge
         this.prevSneakProgress = sneakProgress;
         this.prevTackleProgress = tackleProgress;
         this.prevSleepProgress = sleepProgress;
+        System.out.println("Snow Leopard tick method running!"); // <- Add this line
 
         final boolean sitting = isSitting();
         final boolean slSneaking = isSLSneaking();

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SeagullAIStealFromPlayers.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SeagullAIStealFromPlayers.java
@@ -8,10 +8,14 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -31,6 +35,18 @@ public class SeagullAIStealFromPlayers extends Goal {
 
     @Override
     public boolean canUse() {
+        // 👇 Block stealing if seeds are nearby
+        List<ItemEntity> nearbySeeds = this.seagull.level().getEntitiesOfClass(
+            ItemEntity.class,
+            this.seagull.getBoundingBox().inflate(10.0),
+            item -> item.isAlive() && isSeed(item.getItem())
+        );
+
+        if (!nearbySeeds.isEmpty()) {
+            return false; // Seeds are nearby, don't steal
+        }
+
+        // Existing logic below
         long worldTime = this.seagull.level().getGameTime() % 10;
         if (this.seagull.getNoActionTime() >= 100 && worldTime != 0 || seagull.isSitting() || !AMConfig.seagullStealing) {
             return false;
@@ -38,15 +54,25 @@ public class SeagullAIStealFromPlayers extends Goal {
         if (this.seagull.getRandom().nextInt(12) != 0 && worldTime != 0 || seagull.stealCooldown > 0) {
             return false;
         }
-        if(this.seagull.getMainHandItem().isEmpty()){
+        if (this.seagull.getMainHandItem().isEmpty()) {
             Player valid = getClosestValidPlayer();
-            if(valid != null){
+            if (valid != null) {
                 target = valid;
                 return true;
             }
         }
         return false;
     }
+
+    private boolean isSeed(ItemStack stack) {
+        return stack.is(Items.WHEAT_SEEDS) ||
+               stack.is(Items.BEETROOT_SEEDS) ||
+               stack.is(Items.MELON_SEEDS) ||
+               stack.is(Items.PUMPKIN_SEEDS) ||
+               stack.is(Items.TORCHFLOWER_SEEDS) ||
+               stack.is(Items.PITCHER_POD);
+    }
+    
 
     public void start(){
         this.seagull.aiItemFlag = true;

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SeagullAIStealFromPlayers.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SeagullAIStealFromPlayers.java
@@ -35,32 +35,28 @@ public class SeagullAIStealFromPlayers extends Goal {
 
     @Override
     public boolean canUse() {
-        // 👇 Block stealing if seeds are nearby
-        List<ItemEntity> nearbySeeds = this.seagull.level().getEntitiesOfClass(
-            ItemEntity.class,
-            this.seagull.getBoundingBox().inflate(10.0),
-            item -> item.isAlive() && isSeed(item.getItem())
-        );
-
-        if (!nearbySeeds.isEmpty()) {
-            return false; // Seeds are nearby, don't steal
-        }
-
-        // Existing logic below
-        long worldTime = this.seagull.level().getGameTime() % 10;
-        if (this.seagull.getNoActionTime() >= 100 && worldTime != 0 || seagull.isSitting() || !AMConfig.seagullStealing) {
+        if (seagull.hasEatenSeed) {
+            System.out.println("[DEBUG] Seagull " + seagull.getId() + " will not steal: has eaten a seed.");
             return false;
         }
-        if (this.seagull.getRandom().nextInt(12) != 0 && worldTime != 0 || seagull.stealCooldown > 0) {
+        if (this.seagull.getNoActionTime() >= 100 || seagull.isSitting() || !AMConfig.seagullStealing) {
+            // Only print if you are actively debugging
+            // System.out.println("[DEBUG] Seagull cannot steal due to action time, sitting, or config.");
+            return false;
+        }
+        if (this.seagull.getRandom().nextInt(12) != 0 || seagull.stealCooldown > 0) {
+            // System.out.println("[DEBUG] Seagull cannot steal due to random chance or cooldown.");
             return false;
         }
         if (this.seagull.getMainHandItem().isEmpty()) {
             Player valid = getClosestValidPlayer();
             if (valid != null) {
+                System.out.println("[DEBUG] Seagull " + seagull.getId() + " will try to steal from player: " + valid.getName().getString());
                 target = valid;
                 return true;
             }
         }
+        // System.out.println("[DEBUG] Seagull did not find a valid player to steal from.");
         return false;
     }
 

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SeagullAITargetSeeds.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SeagullAITargetSeeds.java
@@ -1,0 +1,68 @@
+package com.github.alexthe666.alexsmobs.entity.ai;
+
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import java.util.EnumSet;
+import java.util.List;
+
+import com.github.alexthe666.alexsmobs.entity.EntitySeagull;
+
+public class SeagullAITargetSeeds extends Goal {
+    private final EntitySeagull seagull;
+    private ItemEntity targetSeed;
+
+    public SeagullAITargetSeeds(EntitySeagull seagull) {
+        this.seagull = seagull;
+        this.setFlags(EnumSet.of(Goal.Flag.MOVE));
+    }
+
+    @Override
+    public boolean canUse() {
+        List<ItemEntity> items = seagull.level().getEntitiesOfClass(
+            ItemEntity.class,
+            seagull.getBoundingBox().inflate(10.0),
+            item -> item.isAlive() && isSeed(item.getItem())
+        );
+
+        if (!items.isEmpty()) {
+            targetSeed = items.get(0);
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void start() {
+        if (targetSeed != null) {
+            seagull.getNavigation().moveTo(targetSeed, 1.0);
+        }
+    }
+
+    @Override
+    public boolean canContinueToUse() {
+        return targetSeed != null && targetSeed.isAlive();
+    }
+
+    @Override
+    public void tick() {
+        if (targetSeed != null) {
+            seagull.getNavigation().moveTo(targetSeed, 1.0);
+
+            if (seagull.distanceToSqr(targetSeed) < 2.0) {
+                targetSeed.discard(); // "Eat" the seed
+                targetSeed = null;
+            }
+        }
+    }
+
+    private boolean isSeed(ItemStack stack) {
+        Item item = stack.getItem();
+        return item == Items.WHEAT_SEEDS || item == Items.MELON_SEEDS ||
+               item == Items.PUMPKIN_SEEDS || item == Items.BEETROOT_SEEDS;
+    }
+}
+

--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SeagullAITargetSeeds.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/ai/SeagullAITargetSeeds.java
@@ -52,8 +52,28 @@ public class SeagullAITargetSeeds extends Goal {
         if (targetSeed != null) {
             seagull.getNavigation().moveTo(targetSeed, 1.0);
 
-            if (seagull.distanceToSqr(targetSeed) < 2.0) {
-                targetSeed.discard(); // "Eat" the seed
+            if (seagull.distanceToSqr(targetSeed) < 0.5) {
+                if (targetSeed.isAlive()) {
+                    System.out.println("[DEBUG] Seagull " + seagull.getId() + " ate a seed at " + targetSeed.blockPosition());
+                    targetSeed.discard();
+                    seagull.hasEatenSeed = true;
+
+                    // Spawn heart particles for all players (server-side)
+                    if (seagull.level() instanceof net.minecraft.server.level.ServerLevel serverLevel) {
+                        serverLevel.sendParticles(
+                            net.minecraft.core.particles.ParticleTypes.HEART,
+                            seagull.getX(),
+                            seagull.getY() + seagull.getBbHeight(),
+                            seagull.getZ(),
+                            12, // count
+                            0.3, 0.3, 0.3, // spread X, Y, Z
+                            0.0 // speed
+                        );
+                    }
+
+                   
+                    seagull.playSound(net.minecraft.sounds.SoundEvents.PLAYER_LEVELUP, 1.0F, 1.2F);
+                }
                 targetSeed = null;
             }
         }


### PR DESCRIPTION
a small addition
Added and improved a new AI goal for seagulls so that when seeds are present on the ground, seagulls will prioritize targeting and eating the seeds. Upon eating a seed, the seagull becomes passive (will not steal food from players) and displays heart particles and a sound effect to indicate this state. This enhances both the realism and feedback of seagull behaviour in the mod.
and adds a game mechanic solution to players irritation to seagulls stealing food from their inventory!