### PR TITLE
Fix self-damage loop from spike turtle shell helmet

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java
@@ -577,7 +577,7 @@ public class ServerEvents {
                     event.setCanceled(true);
                     return;
                 }
-                if (player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
+                if (attacker != player && player.getItemBySlot(EquipmentSlot.HEAD).getItem() == AMItemRegistry.SPIKED_TURTLE_SHELL.get()) {
                     if (attacker.distanceTo(player) < attacker.getBbWidth() + player.getBbWidth() + 0.5F) {
                         attacker.hurt(attacker.damageSources().thorns(player), 1F);
                         attacker.knockback(0.5F, Mth.sin((attacker.getYRot() + 180) * Mth.DEG_TO_RAD),


### PR DESCRIPTION
Fixes a self-damage loop which happens when:
```sql
attacker == victim AND original_damage_amount < thorn_damage_amount
```
