### PR TITLE
fix: correctly restrict skelewags spawned at structures

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySkelewag.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntitySkelewag.java
@@ -231,7 +231,7 @@ public class EntitySkelewag extends Monster implements IAnimatedEntity {
             drowned.startRiding(this);
             worldIn.addFreshEntityWithPassengers(drowned);
         }
-        if(reason == MobSpawnType.STRUCTURE){
+        if (AMConfig.restrictSkelewagSpawns) {
             this.restrictTo(this.blockPosition(), 15);
         }
         return super.finalizeSpawn(worldIn, difficultyIn, reason, spawnDataIn, dataTag);


### PR DESCRIPTION
The previous if-statement never returned true, as `MobSpawnType.STRUCTURE` only applies when an entity that is saved in an NBT structure is placed in the world (e.g., the initial Iron Golem at villages). Even when Skelewags spawned at shipwrecks in case the `restrictSkelewagSpawns` config option is enabled (which only rarely happens by the way, please see #2257 for that issue), the spawn type was always `MobSpawnType.NATURAL`, so the Skelewags were never restricted to a maximum movement radius.