### PR TITLE
fix: resolve EntityTossedItem initialization issue (#2346)

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityTossedItem.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/entity/EntityTossedItem.java
@@ -12,6 +12,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.ThrowableItemProjectile;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.EntityHitResult;
@@ -22,6 +23,8 @@ import net.neoforged.api.distmarker.OnlyIn;
 public class EntityTossedItem extends ThrowableItemProjectile {
 
     protected static final EntityDataAccessor<Boolean> DART = SynchedEntityData.defineId(EntityTossedItem.class, EntityDataSerializers.BOOLEAN);
+
+    protected static final Item DEFAULT_ITEM = Items.COBBLESTONE;
 
     public EntityTossedItem(EntityType p_i50154_1_, Level p_i50154_2_) {
         super(p_i50154_1_, p_i50154_2_);
@@ -47,6 +50,7 @@ public class EntityTossedItem extends ThrowableItemProjectile {
 
     public void setDart(boolean dart) {
         this.entityData.set(DART, dart);
+        this.setItem(new ItemStack(getDartItem(dart)));
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -124,6 +128,13 @@ public class EntityTossedItem extends ThrowableItemProjectile {
     }
 
     protected Item getDefaultItem() {
-        return isDart() ? AMItemRegistry.ANCIENT_DART.get() : Items.COBBLESTONE;
+        return Items.COBBLESTONE;
+    }
+
+    private static Item getDartItem(boolean dart) {
+        if (dart)
+            return AMItemRegistry.ANCIENT_DART.get();
+
+        return DEFAULT_ITEM;
     }
 }


### PR DESCRIPTION
## Summary

This changes how `EntityTossedItem` determines its projectile item in order to avoid initialization-related issues for Minecraft 1.21.1.

As far as I could trace, issue #2346 happens because `ThrowableItemProjectile` in 1.21.1 calls `getDefaultItem()` during initialization. The current `EntityTossedItem` implementation makes `getDefaultItem()` depend on `isDart()`, which in turn depends on synced entity data that is not initialized yet at that stage.

Current implementation:

```java
protected Item getDefaultItem() {
    return isDart() ? AMItemRegistry.ANCIENT_DART.get() : Items.COBBLESTONE;
}
```

## Changes

* Make `getDefaultItem()` return a single stable fallback item
* Update the projectile `ItemStack` when the dart boolean changes instead of resolving the item dynamically inside `getDefaultItem()`

## Why

From what I could tell while digging through the project and vanilla behavior, `getDefaultItem()` seems intended to behave as a constant fallback provider rather than a state-dependent resolver.

Since `ThrowableItemProjectile` already supports changing its internal `ItemStack`, changing the actual projectile item when the dart state changes appears to be a safer and more stable approach than relying on initialization-time synced data access.

## Notes

A cleaner long-term solution would probably be separating cobblestone and dart projectiles into separate entity classes entirely. However, I wanted to keep this patch as small and non-invasive as possible while stabilizing the current behavior.

I have not tested this change in-game.
