### PR TITLE
Fix hummingbird feeder sweetener tag typo

### DIFF
--- a/src/main/java/com/github/alexthe666/alexsmobs/misc/AMTagRegistry.java
+++ b/src/main/java/com/github/alexthe666/alexsmobs/misc/AMTagRegistry.java
@@ -113,7 +113,7 @@ public class AMTagRegistry {
     public static final TagKey<Item> GRIZZLY_BREEDABLES = registerItemTag("grizzly_breedables");
     public static final TagKey<Item> GRIZZLY_TAMEABLES = registerItemTag("grizzly_tameables");
     public static final TagKey<Item> HUMMINGBIRD_BREEDABLES = registerItemTag("hummingbird_breedables");
-    public static final TagKey<Item> HUMMINGNBIRD_FEEDER_SWEETENERS = registerItemTag("hummingnbird_feeder_sweeteners");
+    public static final TagKey<Item> HUMMINGBIRD_FEEDER_SWEETENERS = registerItemTag("hummingbird_feeder_sweeteners");
     public static final TagKey<Item> JERBOA_BREEDABLES = registerItemTag("jerboa_breedables");
     public static final TagKey<Item> JERBOA_BEGS_FOR = registerItemTag("jerboa_begs_for");
     public static final TagKey<Item> KANGAROO_BREEDABLES = registerItemTag("kangaroo_breedables");


### PR DESCRIPTION
## Summary

While playing Alex's Mobs 1.22.9 on Minecraft Forge 1.20.1, I noticed that the Hummingbird Feeder accepted water bottles but never accepted sugar.

After investigating the source code, I found what appears to be a typo in the registered item tag.

The code currently registers:

```java
registerItemTag("hummingnbird_feeder_sweeteners");
```

while the corresponding resource is:

```
hummingbird_feeder_sweeteners.json
```

This prevents the item tag from matching the resource, so sugar is never recognized by the feeder.

## Fix

- Corrected the registered tag name to match the JSON resource.
- Renamed the corresponding constant references to keep the code consistent.

## Tested

Tested on:

- Minecraft Forge 1.20.1 (47.4.10)
- Alex's Mobs 1.22.9

Verified in-game that:

- ✅ Water bottles are accepted.
- ✅ Sugar is accepted.
- ✅ Hummingbirds correctly use the feeder.

Thanks for your amazing work on Alex's Mobs!
Thank you for your time and for maintaining this mod!